### PR TITLE
Have git and rubocop ignore 'vendor'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+/vendor/bundle
 *.gem
 
 # rspec failure tracking

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,7 @@ AllCops:
   DisplayStyleGuide: true
   Exclude:
     - 'tmp/**/*'
+    - 'vendor/**/*'
   ExtraDetails: true
   TargetRubyVersion: 2.3
 


### PR DESCRIPTION
 (in case the programmer wants to install bundled gems in vendor bundle).