### PR TITLE
Fix gem warnings on open ended or pessimistic dependencies

### DIFF
--- a/pushmi_pullyu.gemspec
+++ b/pushmi_pullyu.gemspec
@@ -23,15 +23,15 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.3.1'
 
-  spec.add_runtime_dependency 'activesupport'
-  spec.add_runtime_dependency 'daemons', '~> 1.2.4'
-  spec.add_runtime_dependency 'redis'
-  spec.add_runtime_dependency 'connection_pool'
+  spec.add_runtime_dependency 'activesupport', '~> 5.0'
+  spec.add_runtime_dependency 'daemons', '~> 1.2', '>= 1.2.4'
+  spec.add_runtime_dependency 'redis', '~> 3.3'
+  spec.add_runtime_dependency 'connection_pool', '~> 2.2'
 
-  spec.add_development_dependency 'bundler', '>= 1.14'
-  spec.add_development_dependency 'rake', '>= 10.0'
-  spec.add_development_dependency 'rspec', '>= 3.0'
-  spec.add_development_dependency 'rubocop', '>= 0.45'
-  spec.add_development_dependency 'pry', '>=  0.10.4'
-  spec.add_development_dependency 'timecop'
+  spec.add_development_dependency 'bundler', '~> 1.14'
+  spec.add_development_dependency 'rake', '~> 12.0'
+  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'rubocop', '~> 0.45'
+  spec.add_development_dependency 'pry', '~> 0.10', '>= 0.10.4'
+  spec.add_development_dependency 'timecop', '~> 0.8'
 end


### PR DESCRIPTION
Fixes the following warnings:

```
WARNING:  open-ended dependency on activesupport (>= 0) is not recommended
  if activesupport is semantically versioned, use:
    add_runtime_dependency 'activesupport', '~> 0'
WARNING:  pessimistic dependency on daemons (~> 1.2.4) may be overly strict
  if daemons is semantically versioned, use:
    add_runtime_dependency 'daemons', '~> 1.2', '>= 1.2.4'
WARNING:  open-ended dependency on redis (>= 0) is not recommended
  if redis is semantically versioned, use:
    add_runtime_dependency 'redis', '~> 0'
WARNING:  open-ended dependency on connection_pool (>= 0) is not recommended
  if connection_pool is semantically versioned, use:
    add_runtime_dependency 'connection_pool', '~> 0'
WARNING:  open-ended dependency on bundler (>= 1.14, development) is not recommended
  if bundler is semantically versioned, use:
    add_development_dependency 'bundler', '~> 1.14'
WARNING:  open-ended dependency on rake (>= 10.0, development) is not recommended
  if rake is semantically versioned, use:
    add_development_dependency 'rake', '~> 10.0'
WARNING:  open-ended dependency on rspec (>= 3.0, development) is not recommended
  if rspec is semantically versioned, use:
    add_development_dependency 'rspec', '~> 3.0'
WARNING:  open-ended dependency on rubocop (>= 0.45, development) is not recommended
  if rubocop is semantically versioned, use:
    add_development_dependency 'rubocop', '~> 0.45'
WARNING:  open-ended dependency on pry (>= 0.10.4, development) is not recommended
  if pry is semantically versioned, use:
    add_development_dependency 'pry', '~> 0.10', '>= 0.10.4'
WARNING:  open-ended dependency on timecop (>= 0, development) is not recommended
  if timecop is semantically versioned, use:
    add_development_dependency 'timecop', '~> 0'
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
```