### PR TITLE
Add redis to travicCI build to fix failing builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
-sudo: false
 language: ruby
+sudo: false
+cache: bundler
+services:
+  - redis-server
+before_install:
+  - gem install bundler
+  - gem update bundler
 rvm:
   - 2.3.3
   - 2.4.0
-before_install: gem install bundler -v 1.14.6


### PR DESCRIPTION
Since we now use redis, Add redis-server service to travisCI to fix failing builds