### PR TITLE
#47: Fixes for Handle PMPY configuration via yaml file

### DIFF
--- a/examples/pushmi_pullyu.yml
+++ b/examples/pushmi_pullyu.yml
@@ -13,13 +13,12 @@ logfile: log/pushmi_pullyu.log
 monitor: false
 piddir: tmp/pids
 process_name: pushmi_pullyu
-
+queue_name: dev:pmpy_queue
+minimum_age: 0
 
 redis:
   host: localhost
   port: 6379
-  queue_name: dev:pmpy_queue
-  minimum_age: 0
 
 solr:
   url: http://localhost:8983/solr/hydra-development

--- a/lib/pushmi_pullyu.rb
+++ b/lib/pushmi_pullyu.rb
@@ -20,10 +20,10 @@ module PushmiPullyu
     monitor: false,
     piddir: PIDDIR,
     process_name: PROCESS_NAME,
+    queue_name: 'dev:pmpy_queue',
     redis: {
       host: 'localhost',
-      port: 6379,
-      queue_name: 'dev:pmpy_queue'
+      port: 6379
     },
     # TODO: rest of these are examples for solr/fedora/swift... feel free to fill them in correctly
     solr: {
@@ -50,6 +50,10 @@ module PushmiPullyu
   end
 
   def self.options=(opts)
+    @options.merge!(opts)
+  end
+
+  def self.override_options(opts)
     @options = opts
   end
 

--- a/lib/pushmi_pullyu.rb
+++ b/lib/pushmi_pullyu.rb
@@ -50,7 +50,7 @@ module PushmiPullyu
   end
 
   def self.options=(opts)
-    @options.merge!(opts)
+    options.merge!(opts)
   end
 
   def self.override_options(opts)

--- a/lib/pushmi_pullyu/cli.rb
+++ b/lib/pushmi_pullyu/cli.rb
@@ -19,7 +19,7 @@ class PushmiPullyu::CLI
     opts[:daemonize] = true if COMMANDS.include? argv[0]
     opts = parse_config(opts[:config_file]).merge(opts) if opts[:config_file]
 
-    options.merge!(opts)
+    PushmiPullyu.options = opts
   end
 
   def run
@@ -112,6 +112,10 @@ class PushmiPullyu::CLI
         opts[:monitor] = true
       end
 
+      o.on('-q', '--queue NAME', 'Name of the queue to read from') do |queue|
+        opts[:queue_name] = queue
+      end
+
       o.separator ''
       o.separator 'Common options:'
 
@@ -153,7 +157,7 @@ class PushmiPullyu::CLI
                                                   host: options[:redis][:host],
                                                   port: options[:redis][:port]
                                                 },
-                                                queue_name: options[:redis][:queue_name],
+                                                queue_name: options[:queue_name],
                                                 age_at_least: options[:minimum_age])
 
     @running = true # set to false by signal trap

--- a/spec/fixtures/config.yml
+++ b/spec/fixtures/config.yml
@@ -5,9 +5,8 @@ logfile: tmp/pushmi_pullyu.log
 piddir: tmp
 process_name: test_pushmi_pullyu
 minimum_age: 10
+queue_name: test:pmpy_queue
 
 redis:
   host: localhost
   port: 9999
-  queue_name: test:pmpy_queue
-

--- a/spec/fixtures/config_with_envs.yml
+++ b/spec/fixtures/config_with_envs.yml
@@ -1,10 +1,9 @@
 # File is for testing out if ERB can be used within config.yml
 
 debug: true
+queue_name: <%= 'erb_' %>test:pmpy_queue
 
 redis:
   <% ENV['REDIS_HOST'] = '192.168.77.11' %>
   host: <%= ENV['REDIS_HOST'] || 'localhost' %>
   port: 9999
-  queue_name: <%= 'erb_' %>test:pmpy_queue
-

--- a/spec/pushmi_pullyu/cli_spec.rb
+++ b/spec/pushmi_pullyu/cli_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe PushmiPullyu::CLI do
     let!(:opts) { PushmiPullyu.options.dup }
 
     after do
-      PushmiPullyu.options = opts
+      PushmiPullyu.override_options(opts)
     end
 
     it 'initializes setup' do
@@ -102,6 +102,11 @@ RSpec.describe PushmiPullyu::CLI do
         cli.parse(['-a', '900'])
         expect(PushmiPullyu.options[:minimum_age]).to be 900.0
       end
+
+      it 'sets queue' do
+        cli.parse(['-q', 'test:pmpy:queue'])
+        expect(PushmiPullyu.options[:queue_name]).to eq 'test:pmpy:queue'
+      end
     end
 
     describe 'with commands' do
@@ -151,9 +156,9 @@ RSpec.describe PushmiPullyu::CLI do
         expect(PushmiPullyu.options[:piddir]).to eq 'tmp'
         expect(PushmiPullyu.options[:process_name]).to eq 'test_pushmi_pullyu'
         expect(PushmiPullyu.options[:minimum_age]).to be 10
+        expect(PushmiPullyu.options[:queue_name]).to eq 'test:pmpy_queue'
         expect(PushmiPullyu.options[:redis][:host]).to eq 'localhost'
         expect(PushmiPullyu.options[:redis][:port]).to be 9999
-        expect(PushmiPullyu.options[:redis][:queue_name]).to eq 'test:pmpy_queue'
       end
 
       it 'still allows command line arguments to take precedence' do
@@ -179,9 +184,9 @@ RSpec.describe PushmiPullyu::CLI do
 
         expect(PushmiPullyu.options[:config_file]).to eq 'spec/fixtures/config_with_envs.yml'
         expect(PushmiPullyu.options[:debug]).to be_truthy
+        expect(PushmiPullyu.options[:queue_name]).to eq 'erb_test:pmpy_queue'
         expect(PushmiPullyu.options[:redis][:host]).to eq '192.168.77.11'
         expect(PushmiPullyu.options[:redis][:port]).to be 9999
-        expect(PushmiPullyu.options[:redis][:queue_name]).to eq 'erb_test:pmpy_queue'
       end
     end
 


### PR DESCRIPTION
Make queue top level option and fix option setter to be a merge on default options instead of a straight up assignment/override.