### PR TITLE
Add basic error reporting to PMPY

### DIFF
--- a/examples/pushmi_pullyu.yml
+++ b/examples/pushmi_pullyu.yml
@@ -15,6 +15,7 @@ piddir: tmp/pids
 process_name: pushmi_pullyu
 queue_name: dev:pmpy_queue
 minimum_age: 0
+rollbar_token: 'abc123xyz'
 
 redis:
   host: localhost

--- a/lib/pushmi_pullyu/cli.rb
+++ b/lib/pushmi_pullyu/cli.rb
@@ -1,6 +1,7 @@
 require 'erb'
 require 'fileutils'
 require 'optparse'
+require 'rollbar'
 require 'singleton'
 require 'yaml'
 
@@ -26,12 +27,19 @@ class PushmiPullyu::CLI
   end
 
   def run
-    if options[:daemonize]
-      start_server_as_daemon
-    else
-      # If we're running in the foreground sync the output.
-      $stdout.sync = $stderr.sync = true
-      start_server
+    configure_rollbar
+    begin
+      if options[:daemonize]
+        start_server_as_daemon
+      else
+        # If we're running in the foreground sync the output.
+        $stdout.sync = $stderr.sync = true
+        start_server
+      end
+    # rubocop:disable Lint/RescueException
+    rescue Exception => e
+      Rollbar.error(e)
+      raise e
     end
   end
 
@@ -47,6 +55,13 @@ class PushmiPullyu::CLI
   end
 
   private
+
+  def configure_rollbar
+    Rollbar.configure do |config|
+      config.enabled = false unless options[:rollbar_token].present?
+      config.access_token = options[:rollbar_token]
+    end
+  end
 
   def options
     PushmiPullyu.options
@@ -77,6 +92,10 @@ class PushmiPullyu::CLI
 
       o.on('-d', '--debug', 'Enable debug logging') do
         opts[:debug] = true
+      end
+
+      o.on('-r', '--rollbar-token TOKEN', 'Enable error reporting to Rollbar') do |token|
+        opts[:rollbar_token] = token if token.present?
       end
 
       o.on '-C', '--config PATH', 'path to YAML config file' do |config_file|
@@ -139,15 +158,22 @@ class PushmiPullyu::CLI
   def run_tick_loop
     while PushmiPullyu.server_running?
       # Preservation (TODO):
-      # 1. Montior queue
-      # 2. Pop off GenericFile element off queue that are ready to begin process preservation event
       item = @queue.wait_next_item
-      logger.debug(item)
-      # 3. Retrieve GenericFile data in fedora
-      # 4. creation of AIP
-      # 5. bagging and tarring of AIP
-      # 6. Push bag to swift API
-      # 7. Log successful preservation event to log files
+
+      # add additional information about the error context to errors that occur while processing this item.
+      Rollbar.scoped(noid: item) do
+        begin
+        # 3. Retrieve GenericFile data in fedora
+        # 4. creation of AIP
+        # 5. bagging and tarring of AIP
+        # 6. Push bag to swift API
+        # 7. Log successful preservation event to log files
+        rescue => e
+          Rollbar.error(e)
+          # TODO: we could re-raise here and let the daemon die on any preservation error, or just log the issue and
+          # move on to the next item.
+        end
+      end
 
       rotate_logs if PushmiPullyu.reset_logger?
     end

--- a/lib/pushmi_pullyu/preservation_queue.rb
+++ b/lib/pushmi_pullyu/preservation_queue.rb
@@ -35,9 +35,6 @@ class PushmiPullyu::PreservationQueue
     @poll_interval = poll_interval
     @age_at_least = age_at_least
     @queue_name = queue_name
-  rescue StandardError => e
-    # TODO: logging
-    abort("Could not get a valid connection to Redis. #{e}")
   end
 
   def next_item

--- a/pushmi_pullyu.gemspec
+++ b/pushmi_pullyu.gemspec
@@ -24,9 +24,13 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3.1'
 
   spec.add_runtime_dependency 'activesupport', '~> 5.0'
+  spec.add_runtime_dependency 'connection_pool', '~> 2.2'
   spec.add_runtime_dependency 'daemons', '~> 1.2', '>= 1.2.4'
   spec.add_runtime_dependency 'redis', '~> 3.3'
-  spec.add_runtime_dependency 'connection_pool', '~> 2.2'
+  spec.add_runtime_dependency 'rollbar', '~> 2.14'
+
+  # Rollbar recommended json serializer & version
+  spec.add_runtime_dependency 'oj', '~> 2.12.14'
 
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'coveralls', '~> 0.8'

--- a/pushmi_pullyu.gemspec
+++ b/pushmi_pullyu.gemspec
@@ -29,9 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'redis', '~> 3.3'
   spec.add_runtime_dependency 'rollbar', '~> 2.14'
 
-  # Rollbar recommended json serializer & version
-  spec.add_runtime_dependency 'oj', '~> 2.12.14'
-
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'coveralls', '~> 0.8'
   spec.add_development_dependency 'rake', '~> 12.0'

--- a/spec/fixtures/config.yml
+++ b/spec/fixtures/config.yml
@@ -6,6 +6,7 @@ piddir: tmp
 process_name: test_pushmi_pullyu
 minimum_age: 10
 queue_name: test:pmpy_queue
+rollbar_token: 'abc123xyz'
 
 redis:
   host: localhost

--- a/spec/pushmi_pullyu/cli_spec.rb
+++ b/spec/pushmi_pullyu/cli_spec.rb
@@ -27,6 +27,16 @@ RSpec.describe PushmiPullyu::CLI do
         expect(cli).not_to have_received(:start_server)
       end
     end
+
+    context 'should set up Rollbar' do
+      it 'starts working loop as daemon' do
+        PushmiPullyu.options[:rollbar_token] = 'xyzzy'
+
+        cli.run
+
+        expect(Rollbar.configuration.access_token).to eq 'xyzzy'
+      end
+    end
   end
 
   describe '#start_server' do
@@ -95,6 +105,11 @@ RSpec.describe PushmiPullyu::CLI do
       it 'sets to debug mode' do
         cli.parse(['--debug'])
         expect(PushmiPullyu.options[:debug]).to be_truthy
+      end
+
+      it 'sets up Rollbar integration' do
+        cli.parse(['-r', 'asdfjkl11234eieio'])
+        expect(PushmiPullyu.options[:rollbar_token]).to eq 'asdfjkl11234eieio'
       end
 
       it 'sets logfile' do
@@ -170,7 +185,6 @@ RSpec.describe PushmiPullyu::CLI do
         cli.parse(['-C', 'spec/fixtures/config.yml'])
 
         expect(PushmiPullyu.options[:config_file]).to eq 'spec/fixtures/config.yml'
-        expect(PushmiPullyu.options[:debug]).to be_truthy
         expect(PushmiPullyu.options[:logfile]).to eq 'tmp/pushmi_pullyu.log'
         expect(PushmiPullyu.options[:piddir]).to eq 'tmp'
         expect(PushmiPullyu.options[:process_name]).to eq 'test_pushmi_pullyu'
@@ -178,6 +192,7 @@ RSpec.describe PushmiPullyu::CLI do
         expect(PushmiPullyu.options[:queue_name]).to eq 'test:pmpy_queue'
         expect(PushmiPullyu.options[:redis][:host]).to eq 'localhost'
         expect(PushmiPullyu.options[:redis][:port]).to be 9999
+        expect(PushmiPullyu.options[:rollbar_token]).to eq 'abc123xyz'
       end
 
       it 'still allows command line arguments to take precedence' do

--- a/spec/pushmi_pullyu/cli_spec.rb
+++ b/spec/pushmi_pullyu/cli_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe PushmiPullyu::CLI do
       end
     end
 
-    context 'should set up Rollbar' do
-      it 'starts working loop as daemon' do
+    context 'Rollbar' do
+      it 'sets up Rollbar' do
         PushmiPullyu.options[:rollbar_token] = 'xyzzy'
 
         cli.run

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,13 +8,6 @@ require 'pry'
 # Require support scripts
 Dir[File.dirname(__FILE__) + '/support/**/*.rb'].each { |f| require f }
 
-# disable Rollbar reporting even if a Rollbar token is passed
-Rollbar.preconfigure do |config|
-  config.before_process << proc do |_options|
-    raise Rollbar::Ignore
-  end
-end
-
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,13 @@ require 'pry'
 # Require support scripts
 Dir[File.dirname(__FILE__) + '/support/**/*.rb'].each { |f| require f }
 
+# disable Rollbar reporting even if a Rollbar token is passed
+Rollbar.preconfigure do |config|
+  config.before_process << proc do |_options|
+    raise Rollbar::Ignore
+  end
+end
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'

--- a/spec/support/rollbar.rb
+++ b/spec/support/rollbar.rb
@@ -1,0 +1,6 @@
+# disable Rollbar reporting even if a Rollbar token is passed
+Rollbar.preconfigure do |config|
+  config.before_process << proc do |_options|
+    raise Rollbar::Ignore
+  end
+end


### PR DESCRIPTION
Basic reporting of errors to Rollbar. The example run-loop setup will report the error and crash the daemon if an error occurs while retrieving a noid from the queue, or if the noid is retrieved successfully, report any errors that occur in the loop with information about the current noid, but continue on to the next noid. We can tweak this as we like.

Rollbar integration is only active when a token is passed in the options. Rollbar is configured to not pass errors back to the API even with a token configured, if RSpec is running.

I've had to do a localized cop disable to make rubocop happy, but that may indicate that we don't want that cop.

Closes #32 