### PR TITLE
Reverse Rspec/DescribedClass rubocop decision

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -82,3 +82,6 @@ RSpec/ExampleLength:
 
 RSpec/MultipleExpectations:
   Enabled: false
+
+RSpec/DescribedClass:
+  EnforcedStyle: explicit

--- a/spec/pushmi_pullyu/cli_spec.rb
+++ b/spec/pushmi_pullyu/cli_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'tempfile'
 
 RSpec.describe PushmiPullyu::CLI do
-  let(:cli) { described_class.instance }
+  let(:cli) { PushmiPullyu::CLI.instance }
 
   describe '#run' do
     before do

--- a/spec/pushmi_pullyu/logging_spec.rb
+++ b/spec/pushmi_pullyu/logging_spec.rb
@@ -11,27 +11,27 @@ end
 
 RSpec.describe PushmiPullyu::Logging do
   it 'has a default logger' do
-    expect(described_class.logger).to be_a(Logger)
+    expect(PushmiPullyu::Logging.logger).to be_a(Logger)
   end
 
   it 'allows setting of a logger' do
     new_logger = Logger.new(STDERR)
-    described_class.logger = new_logger
-    expect(described_class.logger).to eq(new_logger)
+    PushmiPullyu::Logging.logger = new_logger
+    expect(PushmiPullyu::Logging.logger).to eq(new_logger)
   end
 
   it 'logs' do
-    allow(described_class.logger).to receive(:debug)
+    allow(PushmiPullyu::Logging.logger).to receive(:debug)
 
-    described_class.logger.debug('test')
+    PushmiPullyu::Logging.logger.debug('test')
 
-    expect(described_class.logger).to have_received(:debug).with(an_instance_of(String)).once
+    expect(PushmiPullyu::Logging.logger).to have_received(:debug).with(an_instance_of(String)).once
   end
 
   describe '#reopen' do
     let!(:tmp_dir) { 'tmp/test_dir' }
     let(:logfile) { "#{tmp_dir}/pushmi_pullyu.log" }
-    let(:logger) { described_class.initialize_logger(logfile) }
+    let(:logger) { PushmiPullyu::Logging.initialize_logger(logfile) }
 
     before do
       FileUtils.mkdir_p(tmp_dir)
@@ -45,7 +45,7 @@ RSpec.describe PushmiPullyu::Logging do
       logger.info 'Line 1'
       FileUtils.mv(logfile, "#{logfile}.1")
       logger.info 'Line 2'
-      expect(described_class.reopen).to be(logger)
+      expect(PushmiPullyu::Logging.reopen).to be(logger)
       logger.info 'Line 3'
 
       expect(File.read("#{logfile}.1")).to include('Line 1')
@@ -65,20 +65,20 @@ RSpec.describe PushmiPullyu::Logging do
     end
 
     it 'uses the default logger' do
-      expect(dummy_class.logger).to be described_class.logger
+      expect(dummy_class.logger).to be PushmiPullyu::Logging.logger
     end
 
     it 'allows custom loggers' do
-      described_class.logger = Logger.new(STDERR)
-      expect(dummy_class.logger).to be described_class.logger
+      PushmiPullyu::Logging.logger = Logger.new(STDERR)
+      expect(dummy_class.logger).to be PushmiPullyu::Logging.logger
     end
 
     it 'logs' do
-      allow(described_class.logger).to receive(:info)
+      allow(PushmiPullyu::Logging.logger).to receive(:info)
 
       dummy_class.logger.info('test')
 
-      expect(described_class.logger).to have_received(:info).with(an_instance_of(String)).once
+      expect(PushmiPullyu::Logging.logger).to have_received(:info).with(an_instance_of(String)).once
     end
   end
 end

--- a/spec/pushmi_pullyu/preservation_queue_spec.rb
+++ b/spec/pushmi_pullyu/preservation_queue_spec.rb
@@ -3,7 +3,7 @@ require 'timecop'
 
 RSpec.describe PushmiPullyu::PreservationQueue do
   describe 'a queue with 3 items in it' do
-    let(:queue) { described_class.new(poll_interval: 0, queue_name: 'test:pmpy_queue') }
+    let(:queue) { PushmiPullyu::PreservationQueue.new(poll_interval: 0, queue_name: 'test:pmpy_queue') }
 
     before do
       PushmiPullyu.server_running = true
@@ -24,7 +24,7 @@ RSpec.describe PushmiPullyu::PreservationQueue do
 
   describe 'a queue with items under a minimum age' do
     let(:queue) do
-      described_class.new(poll_interval: 0, queue_name: 'test:pmpy_queue', age_at_least: 15.minutes)
+      PushmiPullyu::PreservationQueue.new(poll_interval: 0, queue_name: 'test:pmpy_queue', age_at_least: 15.minutes)
     end
 
     before do


### PR DESCRIPTION
Team agreed that it's better to use explicit style instead of described_class style for rspec tests. Changing cop to reflect this.

So from now on use explicit style (PushmiPullyu::ClassName) instead of described_class helper

Updated all specs affected by this as well.