### PR TITLE
Make sure we are adding metadata to swift deposits as in AIP spec

### DIFF
--- a/lib/pushmi_pullyu/swift_depositer.rb
+++ b/lib/pushmi_pullyu/swift_depositer.rb
@@ -28,7 +28,24 @@ class PushmiPullyu::SwiftDepositer
                      else
                        era_container.create_object(file_base_name)
                      end
-    deposited_file.write(File.open(file_name), 'etag' => hash, 'content-type' => 'application/x-tar')
+
+    # Add swift metadata with in accordance to AIP spec:
+    # https://docs.google.com/document/d/154BqhDPAdGW-I9enrqLpBYbhkF9exX9lV3kMaijuwPg/edit#
+    metadata = {
+      project: 'ERA',
+      project_id: file_base_name,
+      promise: 'bronze',
+      retention: nil,
+      depositor: nil,
+      aip_version: '1.0'
+    }
+
+    # ruby-openstack wants all keys of the metadata to be named like "X-Object-Meta-{{Key}}", so update them
+    metadata.transform_keys! { |key| "X-Object-Meta-#{key}" }
+
+    deposited_file.write(File.open(file_name),
+                         { 'etag' => hash,
+                           'content-type' => 'application/x-tar' }.merge(metadata))
 
     deposited_file
   end

--- a/lib/pushmi_pullyu/swift_depositer.rb
+++ b/lib/pushmi_pullyu/swift_depositer.rb
@@ -19,7 +19,7 @@ class PushmiPullyu::SwiftDepositer
   def deposit_file(file_name, swift_container)
     file_base_name = File.basename(file_name, '.*')
 
-    hash = Digest::MD5.file(file_name).hexdigest
+    checksum = Digest::MD5.file(file_name).hexdigest
 
     era_container = swift_connection.container(swift_container)
 
@@ -35,8 +35,6 @@ class PushmiPullyu::SwiftDepositer
       project: 'ERA',
       project_id: file_base_name,
       promise: 'bronze',
-      retention: nil,
-      depositor: nil,
       aip_version: '1.0'
     }
 
@@ -44,7 +42,7 @@ class PushmiPullyu::SwiftDepositer
     metadata.transform_keys! { |key| "X-Object-Meta-#{key}" }
 
     deposited_file.write(File.open(file_name),
-                         { 'etag' => hash,
+                         { 'etag' => checksum,
                            'content-type' => 'application/x-tar' }.merge(metadata))
 
     deposited_file

--- a/spec/pushmi_pullyu/swift_depositer_spec.rb
+++ b/spec/pushmi_pullyu/swift_depositer_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe PushmiPullyu::SwiftDepositer do
         expect(deposited_file).to be_an_instance_of(OpenStack::Swift::StorageObject)
         expect(deposited_file.name).to eql 'config'
         expect(deposited_file.container.name).to eql 'ERA'
+        expect(deposited_file.metadata['project']).to eql 'ERA'
+        expect(deposited_file.metadata['project-id']).to eql 'config'
+        expect(deposited_file.metadata['aip-version']).to eql '1.0'
+        expect(deposited_file.metadata['promise']).to eql 'bronze'
       end
     end
 

--- a/spec/support/http_cache/vcr/swift_new_deposit.yml
+++ b/spec/support/http_cache/vcr/swift_new_deposit.yml
@@ -25,22 +25,22 @@ http_interactions:
       X-Storage-Url:
       - http://www.example.com:8080/v1/AUTH_test
       X-Auth-Token:
-      - AUTH_tkb95013a506e048d184148129ea587463
+      - AUTH_tkdce22ed367cd43c1b5fa3c7cf010e185
       Content-Type:
       - text/html; charset=UTF-8
       X-Storage-Token:
-      - AUTH_tkb95013a506e048d184148129ea587463
+      - AUTH_tkdce22ed367cd43c1b5fa3c7cf010e185
       Content-Length:
       - '0'
       X-Trans-Id:
-      - txcc4dfacb7c1a45bb8b977-005928b172
+      - txb040762d0c5140dfbfa31-005931ae72
       Date:
-      - Fri, 26 May 2017 22:51:30 GMT
+      - Fri, 02 Jun 2017 18:29:06 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 May 2017 22:51:30 GMT
+  recorded_at: Fri, 02 Jun 2017 18:29:06 GMT
 - request:
     method: head
     uri: http://www.example.com:8080/v1/AUTH_test/ERA
@@ -49,9 +49,9 @@ http_interactions:
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tkb95013a506e048d184148129ea587463
+      - AUTH_tkdce22ed367cd43c1b5fa3c7cf010e185
       X-Storage-Token:
-      - AUTH_tkb95013a506e048d184148129ea587463
+      - AUTH_tkdce22ed367cd43c1b5fa3c7cf010e185
       Connection:
       - Keep-Alive
       User-Agent:
@@ -68,26 +68,26 @@ http_interactions:
       Content-Length:
       - '0'
       X-Container-Object-Count:
-      - '1'
+      - '3'
       Accept-Ranges:
       - bytes
       X-Timestamp:
       - '1495836578.02094'
       X-Container-Bytes-Used:
-      - '230'
+      - '509'
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx1965971658ea48339660c-005928b172
+      - txa6a50422099f45c5ae1ca-005931ae72
       Date:
-      - Fri, 26 May 2017 22:51:30 GMT
+      - Fri, 02 Jun 2017 18:29:06 GMT
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 May 2017 22:51:30 GMT
+  recorded_at: Fri, 02 Jun 2017 18:29:06 GMT
 - request:
     method: head
     uri: http://www.example.com:8080/v1/AUTH_test/ERA/config
@@ -96,9 +96,9 @@ http_interactions:
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tkb95013a506e048d184148129ea587463
+      - AUTH_tkdce22ed367cd43c1b5fa3c7cf010e185
       X-Storage-Token:
-      - AUTH_tkb95013a506e048d184148129ea587463
+      - AUTH_tkdce22ed367cd43c1b5fa3c7cf010e185
       Connection:
       - Keep-Alive
       User-Agent:
@@ -109,69 +109,79 @@ http_interactions:
       - application/json
   response:
     status:
-      code: 404
-      message: Not Found
+      code: 200
+      message: OK
     headers:
       Content-Length:
-      - '0'
+      - '279'
+      Accept-Ranges:
+      - bytes
+      Last-Modified:
+      - Fri, 26 May 2017 22:51:31 GMT
+      Etag:
+      - 0f32868de20f3b1d4685bfa497a2c243
+      X-Timestamp:
+      - '1495839090.86463'
       Content-Type:
-      - text/html; charset=UTF-8
+      - application/x-tar
       X-Trans-Id:
-      - tx06873d1706824beaa36a4-005928b172
+      - txbfa1f8cfbfc544e28159e-005931ae72
       Date:
-      - Fri, 26 May 2017 22:51:30 GMT
+      - Fri, 02 Jun 2017 18:29:06 GMT
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 May 2017 22:51:30 GMT
+  recorded_at: Fri, 02 Jun 2017 18:29:06 GMT
 - request:
-    method: put
+    method: head
     uri: http://www.example.com:8080/v1/AUTH_test/ERA/config
     body:
-      encoding: UTF-8
+      encoding: US-ASCII
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tkb95013a506e048d184148129ea587463
+      - AUTH_tkdce22ed367cd43c1b5fa3c7cf010e185
       X-Storage-Token:
-      - AUTH_tkb95013a506e048d184148129ea587463
+      - AUTH_tkdce22ed367cd43c1b5fa3c7cf010e185
       Connection:
       - Keep-Alive
       User-Agent:
       - OpenStack Ruby API 2.6.8
       Accept:
       - application/json
-      Content-Length:
-      - '0'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Content-Type:
+      - application/json
   response:
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
     headers:
+      Content-Length:
+      - '279'
+      Accept-Ranges:
+      - bytes
       Last-Modified:
       - Fri, 26 May 2017 22:51:31 GMT
-      Content-Length:
-      - '0'
       Etag:
-      - d41d8cd98f00b204e9800998ecf8427e
+      - 0f32868de20f3b1d4685bfa497a2c243
+      X-Timestamp:
+      - '1495839090.86463'
       Content-Type:
-      - text/html; charset=UTF-8
+      - application/x-tar
       X-Trans-Id:
-      - tx62828675531a4799806fe-005928b172
+      - txa2487582a0794ab1b04f5-005931ae72
       Date:
-      - Fri, 26 May 2017 22:51:30 GMT
+      - Fri, 02 Jun 2017 18:29:06 GMT
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 May 2017 22:51:30 GMT
+  recorded_at: Fri, 02 Jun 2017 18:29:06 GMT
 - request:
     method: put
     uri: http://www.example.com:8080/v1/AUTH_test/ERA/config
@@ -193,9 +203,9 @@ http_interactions:
           port: 9999
     headers:
       X-Auth-Token:
-      - AUTH_tkb95013a506e048d184148129ea587463
+      - AUTH_tkdce22ed367cd43c1b5fa3c7cf010e185
       X-Storage-Token:
-      - AUTH_tkb95013a506e048d184148129ea587463
+      - AUTH_tkdce22ed367cd43c1b5fa3c7cf010e185
       Connection:
       - Keep-Alive
       User-Agent:
@@ -206,6 +216,14 @@ http_interactions:
       - 0f32868de20f3b1d4685bfa497a2c243
       Content-Type:
       - application/x-tar
+      X-Object-Meta-Project:
+      - ERA
+      X-Object-Meta-Project-Id:
+      - config
+      X-Object-Meta-Promise:
+      - bronze
+      X-Object-Meta-Aip-Version:
+      - '1.0'
       Transfer-Encoding:
       - chunked
       Accept-Encoding:
@@ -216,7 +234,7 @@ http_interactions:
       message: Created
     headers:
       Last-Modified:
-      - Fri, 26 May 2017 22:51:31 GMT
+      - Fri, 02 Jun 2017 18:29:07 GMT
       Content-Length:
       - '0'
       Etag:
@@ -224,14 +242,234 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - txf3a155e36a0149eba58ec-005928b172
+      - txabe3b0232dac46f09a223-005931ae72
       Date:
-      - Fri, 26 May 2017 22:51:30 GMT
+      - Fri, 02 Jun 2017 18:29:06 GMT
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 May 2017 22:51:30 GMT
+  recorded_at: Fri, 02 Jun 2017 18:29:06 GMT
+- request:
+    method: head
+    uri: http://www.example.com:8080/v1/AUTH_test/ERA/config
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Auth-Token:
+      - AUTH_tkdce22ed367cd43c1b5fa3c7cf010e185
+      X-Storage-Token:
+      - AUTH_tkdce22ed367cd43c1b5fa3c7cf010e185
+      Connection:
+      - Keep-Alive
+      User-Agent:
+      - OpenStack Ruby API 2.6.8
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Object-Meta-Project-Id:
+      - config
+      Content-Length:
+      - '279'
+      X-Object-Meta-Aip-Version:
+      - '1.0'
+      Accept-Ranges:
+      - bytes
+      Last-Modified:
+      - Fri, 02 Jun 2017 18:29:07 GMT
+      Etag:
+      - 0f32868de20f3b1d4685bfa497a2c243
+      X-Timestamp:
+      - '1496428146.23896'
+      X-Object-Meta-Promise:
+      - bronze
+      X-Object-Meta-Project:
+      - ERA
+      Content-Type:
+      - application/x-tar
+      X-Trans-Id:
+      - txef506cbc92c341089bad6-005931ae72
+      Date:
+      - Fri, 02 Jun 2017 18:29:06 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 02 Jun 2017 18:29:06 GMT
+- request:
+    method: head
+    uri: http://www.example.com:8080/v1/AUTH_test/ERA/config
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Auth-Token:
+      - AUTH_tkdce22ed367cd43c1b5fa3c7cf010e185
+      X-Storage-Token:
+      - AUTH_tkdce22ed367cd43c1b5fa3c7cf010e185
+      Connection:
+      - Keep-Alive
+      User-Agent:
+      - OpenStack Ruby API 2.6.8
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Object-Meta-Project-Id:
+      - config
+      Content-Length:
+      - '279'
+      X-Object-Meta-Aip-Version:
+      - '1.0'
+      Accept-Ranges:
+      - bytes
+      Last-Modified:
+      - Fri, 02 Jun 2017 18:29:07 GMT
+      Etag:
+      - 0f32868de20f3b1d4685bfa497a2c243
+      X-Timestamp:
+      - '1496428146.23896'
+      X-Object-Meta-Promise:
+      - bronze
+      X-Object-Meta-Project:
+      - ERA
+      Content-Type:
+      - application/x-tar
+      X-Trans-Id:
+      - tx6af35c5650b140c1b0e55-005931ae72
+      Date:
+      - Fri, 02 Jun 2017 18:29:06 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 02 Jun 2017 18:29:06 GMT
+- request:
+    method: head
+    uri: http://www.example.com:8080/v1/AUTH_test/ERA/config
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Auth-Token:
+      - AUTH_tkdce22ed367cd43c1b5fa3c7cf010e185
+      X-Storage-Token:
+      - AUTH_tkdce22ed367cd43c1b5fa3c7cf010e185
+      Connection:
+      - Keep-Alive
+      User-Agent:
+      - OpenStack Ruby API 2.6.8
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Object-Meta-Project-Id:
+      - config
+      Content-Length:
+      - '279'
+      X-Object-Meta-Aip-Version:
+      - '1.0'
+      Accept-Ranges:
+      - bytes
+      Last-Modified:
+      - Fri, 02 Jun 2017 18:29:07 GMT
+      Etag:
+      - 0f32868de20f3b1d4685bfa497a2c243
+      X-Timestamp:
+      - '1496428146.23896'
+      X-Object-Meta-Promise:
+      - bronze
+      X-Object-Meta-Project:
+      - ERA
+      Content-Type:
+      - application/x-tar
+      X-Trans-Id:
+      - txbdbdd8d0d0034cd4a7336-005931ae72
+      Date:
+      - Fri, 02 Jun 2017 18:29:06 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 02 Jun 2017 18:29:06 GMT
+- request:
+    method: head
+    uri: http://www.example.com:8080/v1/AUTH_test/ERA/config
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Auth-Token:
+      - AUTH_tkdce22ed367cd43c1b5fa3c7cf010e185
+      X-Storage-Token:
+      - AUTH_tkdce22ed367cd43c1b5fa3c7cf010e185
+      Connection:
+      - Keep-Alive
+      User-Agent:
+      - OpenStack Ruby API 2.6.8
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Object-Meta-Project-Id:
+      - config
+      Content-Length:
+      - '279'
+      X-Object-Meta-Aip-Version:
+      - '1.0'
+      Accept-Ranges:
+      - bytes
+      Last-Modified:
+      - Fri, 02 Jun 2017 18:29:07 GMT
+      Etag:
+      - 0f32868de20f3b1d4685bfa497a2c243
+      X-Timestamp:
+      - '1496428146.23896'
+      X-Object-Meta-Promise:
+      - bronze
+      X-Object-Meta-Project:
+      - ERA
+      Content-Type:
+      - application/x-tar
+      X-Trans-Id:
+      - tx4a1106daad5f41c297141-005931ae72
+      Date:
+      - Fri, 02 Jun 2017 18:29:06 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 02 Jun 2017 18:29:06 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
Something we haven't been doing yet.

From according to AIP spec( https://docs.google.com/document/d/154BqhDPAdGW-I9enrqLpBYbhkF9exX9lV3kMaijuwPg/edit) we need to add metadata when we upload our deposited files in Swift:

```
Ingest to Swift
Swift container: “ERA”
Swift path: <NOID>
 
The identifier in Swift will normally be the NOID generated in ERA. It may be some other identifier for non-ERA content (an identifier used in that project, or a UUID if nothing else is available). Swift X-Object-Meta name-value pairs will be populated:
 
project: normally “ERA” (this may become redundant if we always use a container per project, but we haven’t determined that yet)
Project_id: (i.e. the id of this object within the project) - normally the NOID
promise: a label for the level of preservation promised 
This will ultimately cover various levels of preservation as defined in the UAL Digital Preservation Plan (gold, silver, bronze). For lightweight AIPS this will always be “bronze”.
retention: (optional) a timestamp indicating when some action expressed by the promise will be taken
Not applicable to ERA content, but for other content we might use it to trigger a review after 10 years etc.
depositor: (optional) name of a non-UAL depositor
AIPversion: 1.0
```

From looking at it, the metadata on every file in PushmiPullyu should look something like as a result:
```ruby
  metadata = {
    project: 'ERA',
    project_id: file_base_name, #we name the files with the noid so should be the same
    promise: 'bronze',
    aip_version: '1.0'
    }
```