### PR TITLE
Chage code to write file content during file creation

### DIFF
--- a/lib/pushmi_pullyu/swift_depositer.rb
+++ b/lib/pushmi_pullyu/swift_depositer.rb
@@ -23,11 +23,9 @@ class PushmiPullyu::SwiftDepositer
 
     era_container = swift_connection.container(swift_container)
 
-    object_exists = era_container.object_exists?(file_base_name)
-
     # Add swift metadata with in accordance to AIP spec:
     # https://docs.google.com/document/d/154BqhDPAdGW-I9enrqLpBYbhkF9exX9lV3kMaijuwPg/edit#
-    swift_metadata = {
+    metadata = {
       project: 'ERA',
       project_id: file_base_name,
       promise: 'bronze',
@@ -35,18 +33,17 @@ class PushmiPullyu::SwiftDepositer
     }
 
     # ruby-openstack wants all keys of the metadata to be named like "X-Object-Meta-{{Key}}", so update them
-    swift_metadata.transform_keys! { |key| "X-Object-Meta-#{key}" }
+    metadata.transform_keys! { |key| "X-Object-Meta-#{key}" }
 
-    # creatre file metadata
-    file_metadata = { 'etag' => checksum,
-                      'content-type' => 'application/x-tar' }.merge(swift_metadata)
+    headers = { 'etag' => checksum,
+                'content-type' => 'application/x-tar' }.merge(metadata)
 
-    # create new file
-    return era_container.create_object(file_base_name, file_metadata, File.open(file_name)) unless object_exists
-
-    # update existing one
-    deposited_file = era_container.object(file_base_name)
-    deposited_file.write(File.open(file_name), file_metadata)
+    if era_container.object_exists?(file_base_name)
+      deposited_file = era_container.object(file_base_name)
+      deposited_file.write(File.open(file_name), headers)
+    else
+      deposited_file = era_container.create_object(file_base_name, headers, File.open(file_name))
+    end
 
     deposited_file
   end


### PR DESCRIPTION
We have small bug in the current swift_depositor.rb code. When new swift object is created we use two API calls - one to create an object, another to write data to it. When archiving is turned on on the container, that cases file archive of 0 size been created when data in the file being updated. Fix is simple, just need to write file data in the create method.