### PR TITLE
Fix loading issue with compact nested module syntax

### DIFF
--- a/lib/pushmi_pullyu.rb
+++ b/lib/pushmi_pullyu.rb
@@ -1,3 +1,8 @@
+# require 'pushmi_pullyu/version' must be first as it declares the PushmiPullyu module.
+# (This fixes a weird NameError bug when using the nested compact syntax for
+# defining modules/classes like `module PushmiPullyu::Logging`)
+require 'pushmi_pullyu/version'
+
 require 'pushmi_pullyu/logging'
 
 require 'pushmi_pullyu/aip'
@@ -8,7 +13,6 @@ require 'pushmi_pullyu/aip/fedora_fetcher'
 require 'pushmi_pullyu/cli'
 require 'pushmi_pullyu/preservation_queue'
 require 'pushmi_pullyu/swift_depositer'
-require 'pushmi_pullyu/version'
 
 require 'active_support'
 require 'active_support/core_ext'

--- a/lib/pushmi_pullyu/version.rb
+++ b/lib/pushmi_pullyu/version.rb
@@ -1,3 +1,3 @@
 module PushmiPullyu
-  VERSION = '0.2.1'.freeze
+  VERSION = '0.2.2'.freeze
 end


### PR DESCRIPTION
pushmipullyu gem was failing with the following error:
```ruby
/blah/gems/pushmi_pullyu-0.2.1/lib/pushmi_pullyu/logging.rb:4:in `<top (required)>': uninitialized constant PushmiPullyu (NameError)
```
This provides a fix for it. The issue was using the syntax `module PushmiPullyu::Logging` assumes the PushmiPullyu module has already been declared. Which it currently doesn't at this point. This can be fixed with either changing this syntax to use the longer version:
```
module PushmiPullyu
  module Logging
```
Or a better solution is to move the version file to be the first thing that gets required (as it defines the PushmiPullyu module itself).


Already bumped the version number so we can release this right after this get's merged.