### PR TITLE
update rollbar config to allow it to use proxy

### DIFF
--- a/examples/pushmi_pullyu.yml
+++ b/examples/pushmi_pullyu.yml
@@ -17,6 +17,7 @@ process_name: pushmi_pullyu
 queue_name: dev:pmpy_queue
 minimum_age: 0
 rollbar_token: 'abc123xyz'
+rollbar_endpoint: 'your_proxy_url'
 
 redis:
   url: redis://localhost:6379

--- a/lib/pushmi_pullyu/cli.rb
+++ b/lib/pushmi_pullyu/cli.rb
@@ -58,6 +58,7 @@ class PushmiPullyu::CLI
     Rollbar.configure do |config|
       config.enabled = false unless options[:rollbar_token].present?
       config.access_token = options[:rollbar_token]
+      config.endpoint = options[:rollbar_endpoint]
     end
   end
 


### PR DESCRIPTION
In order to use rollbar through a proxy, need to let PMPY to talk to the endpoint on the proxy. 