### PR TITLE
Rubocop warns about a renamed namespace that affects the config file.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,7 +59,7 @@ Style/ClassAndModuleChildren:
 Style/Documentation:
   Enabled: false
 
-Style/FileName:
+Naming/FileName:
   Exclude:
     - Dangerfile
     - Rakefile


### PR DESCRIPTION
Here is a detailed summary, just for you ualberta-bot!