### PR TITLE
Add authentication to allow list source to be loaded

### DIFF
--- a/lib/pushmi_pullyu/aip/file_list_creator.rb
+++ b/lib/pushmi_pullyu/aip/file_list_creator.rb
@@ -1,5 +1,6 @@
 require 'rdf'
 require 'rdf/n3'
+require 'rest-client'
 
 class PushmiPullyu::AIP::FileListCreator
 
@@ -20,6 +21,9 @@ class PushmiPullyu::AIP::FileListCreator
 
   def initialize(list_source_uri, output_xml_file, file_set_uuids)
     @uri = RDF::URI(list_source_uri)
+    @auth_uri = RDF::URI(list_source_uri)
+    @auth_uri.user = PushmiPullyu.options[:fedora][:user]
+    @auth_uri.password = PushmiPullyu.options[:fedora][:password]
     @output_file = output_xml_file
 
     # These are the known fileset uuids, used for validation
@@ -36,8 +40,7 @@ class PushmiPullyu::AIP::FileListCreator
   def extract_list_source_uuids
     # Note: raises IOError if can't find
     #       raises RDF::ReaderError if can't parse
-    @graph = RDF::Graph.load(@uri, validate: true)
-
+    @graph = RDF::Graph.load(@auth_uri, validate: true)
     @list_source_uuids = []
 
     # Fetch first FileSet in list source

--- a/lib/pushmi_pullyu/version.rb
+++ b/lib/pushmi_pullyu/version.rb
@@ -1,3 +1,3 @@
 module PushmiPullyu
-  VERSION = '0.2.7'.freeze
+  VERSION = '1.0.1'.freeze
 end

--- a/lib/pushmi_pullyu/version.rb
+++ b/lib/pushmi_pullyu/version.rb
@@ -1,3 +1,3 @@
 module PushmiPullyu
-  VERSION = '1.0.1'.freeze
+  VERSION = '1.0.2'.freeze
 end

--- a/pushmi_pullyu.gemspec
+++ b/pushmi_pullyu.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'rdf', '>= 1.99', '< 4.0'
   spec.add_runtime_dependency 'rdf-n3', '>= 1.99', '< 4.0'
   spec.add_runtime_dependency 'redis', '>= 3.3', '< 5.0'
+  spec.add_runtime_dependency 'rest-client', '~> 1.8'
   spec.add_runtime_dependency 'rollbar', '~> 2.14'
 
   spec.add_development_dependency 'bundler', '~> 1.14'


### PR DESCRIPTION
To allow the RDF gem to load the graph so that it can get the ordering of the files, it needs to authorize the access to list_source. 
