### PR TITLE
Fix spurious error when stopping service

### DIFF
--- a/lib/pushmi_pullyu/cli.rb
+++ b/lib/pushmi_pullyu/cli.rb
@@ -169,6 +169,7 @@ class PushmiPullyu::CLI
 
   def run_preservation_cycle
     item = queue.wait_next_item
+    return unless item.present?
 
     # add additional information about the error context to errors that occur while processing this item.
     Rollbar.scoped(noid: item) do


### PR DESCRIPTION
I think this should resolve the issue Weiwei ran into this morning. I believe what's happening here is that when `PushmiPullyu.continue_polling?` is false, `wait_next_item` returns nil [here](https://github.com/ualbertalib/pushmi_pullyu/blob/master/lib/pushmi_pullyu/preservation_queue.rb#L62), feeding a [final nil item into the preservation cycle](https://github.com/ualbertalib/pushmi_pullyu/blob/master/lib/pushmi_pullyu/preservation_queue.rb#L62) prior to finally exiting. By returning immediately if the received item is nil, we jump directly to [exiting the preservation cycle](https://github.com/ualbertalib/pushmi_pullyu/blob/master/lib/pushmi_pullyu/cli.rb#L198).