### PR TITLE
have to move db connection back to where the connection is actually needed

### DIFF
--- a/lib/pushmi_pullyu/aip/downloader.rb
+++ b/lib/pushmi_pullyu/aip/downloader.rb
@@ -151,6 +151,7 @@ class PushmiPullyu::AIP::Downloader
 
   def clean_directories
     return unless File.exist?(@aip_directory)
+
     PushmiPullyu.logger.debug("#{@noid}: Nuking directories ...")
     FileUtils.rm_rf(@aip_directory)
   end

--- a/lib/pushmi_pullyu/aip/fedora_fetcher.rb
+++ b/lib/pushmi_pullyu/aip/fedora_fetcher.rb
@@ -46,6 +46,7 @@ class PushmiPullyu::AIP::FedoraFetcher
       return true
     elsif response.is_a?(Net::HTTPNotFound)
       raise FedoraFetchError unless optional
+
       return false
     else
       raise FedoraFetchError

--- a/lib/pushmi_pullyu/aip/file_list_creator.rb
+++ b/lib/pushmi_pullyu/aip/file_list_creator.rb
@@ -53,6 +53,7 @@ class PushmiPullyu::AIP::FileListCreator
       break if next_proxy.nil?
 
       raise NextPreviousProxyMismatch if this_proxy != find_prev_proxy(next_proxy)
+
       this_proxy = next_proxy
     end
 
@@ -76,6 +77,7 @@ class PushmiPullyu::AIP::FileListCreator
       first_uri = statement.object
       # Validate that the first proxy doesn't have a previous one
       raise FirstProxyHasPrev, @uri.to_s if find_prev_proxy(first_uri)
+
       return first_uri
     end
     raise NoFirstProxyFound, @uri.to_s
@@ -86,6 +88,7 @@ class PushmiPullyu::AIP::FileListCreator
       last_uri = statement.object
       # Validate that the last proxy doesn't have a next one
       raise LastProxyHasNext, @uri.to_s if find_next_proxy(last_uri)
+
       return last_uri
     end
     raise LastProxyFound, @uri.to_s

--- a/lib/pushmi_pullyu/aip/owner_email_editor.rb
+++ b/lib/pushmi_pullyu/aip/owner_email_editor.rb
@@ -11,6 +11,7 @@ class PushmiPullyu::AIP::OwnerEmailEditor
   end
 
   def run
+    setup_db_connection
     is_modified = false
     prefixes = nil
     # Read once to load prefixes (the @things at the top of an n3 file)
@@ -33,6 +34,16 @@ class PushmiPullyu::AIP::OwnerEmailEditor
     end
     return new_body if is_modified
     raise NoOwnerPredicate
+  end
+
+  private
+
+  def setup_db_connection
+    ActiveRecord::Base.establish_connection(database_configuration)
+  end
+
+  def database_configuration
+    PushmiPullyu.options[:database][:url]
   end
 
 end

--- a/lib/pushmi_pullyu/aip/owner_email_editor.rb
+++ b/lib/pushmi_pullyu/aip/owner_email_editor.rb
@@ -33,6 +33,7 @@ class PushmiPullyu::AIP::OwnerEmailEditor
       end
     end
     return new_body if is_modified
+
     raise NoOwnerPredicate
   end
 

--- a/lib/pushmi_pullyu/cli.rb
+++ b/lib/pushmi_pullyu/cli.rb
@@ -48,7 +48,6 @@ class PushmiPullyu::CLI
     setup_signal_traps
 
     setup_log
-    setup_db_connection
     print_banner
 
     run_tick_loop
@@ -274,14 +273,6 @@ class PushmiPullyu::CLI
       Dir.chdir(pwd)
       start_server
     end
-  end
-
-  def setup_db_connection
-    ActiveRecord::Base.establish_connection(database_configuration)
-  end
-
-  def database_configuration
-    PushmiPullyu.options[:database][:url]
   end
 
 end

--- a/lib/pushmi_pullyu/preservation_queue.rb
+++ b/lib/pushmi_pullyu/preservation_queue.rb
@@ -63,6 +63,7 @@ class PushmiPullyu::PreservationQueue
     while PushmiPullyu.continue_polling?
       element = next_item
       return element if element.present?
+
       sleep @poll_interval
     end
   end

--- a/lib/pushmi_pullyu/version.rb
+++ b/lib/pushmi_pullyu/version.rb
@@ -1,3 +1,3 @@
 module PushmiPullyu
-  VERSION = '1.0.4'.freeze
+  VERSION = '1.0.5'.freeze
 end


### PR DESCRIPTION
We moved the DB connection setup to the console but the connection set up happens when the daemon was first started/restarted, and the connection will idle for a prolonged period of time and will be closed by the PostgreSQL DB. And when reading from DB is actually needed, the connection has often been killed by PG already. 

Move the db connection set up to where the connection is actually needed. This might be moved back to cli, once the PG DB we use is upgraded to the latest version, in which a connection timeout can be specified in the DB configuration. 