### PR TITLE
Fix danger error message

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,7 @@ AllCops:
   Exclude:
     - 'tmp/**/*'
     - 'vendor/**/*'
+    - 'Dangerfile'
   ExtraDetails: true
   TargetRubyVersion: 2.5
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -16,9 +16,8 @@ warn('Please add a detailed summary in the description.') if github.pr_body.leng
 # Let people say that this isn't worth a CHANGELOG entry in the PR if they choose
 declared_trivial = (github.pr_title + github.pr_body).include?('#trivial') || !has_app_changes
 
-if !git.modified_files.include?('CHANGELOG.md') && !declared_trivial
-  fail("Please include a CHANGELOG entry. \nYou can find it at " \
-    '[CHANGELOG.md](https://github.com/ualbertalib/jupiter/blob/master/CHANGELOG.md).', sticky: false)
+if !git.modified_files.include?("CHANGELOG.md") && !declared_trivial
+  fail("Please include a CHANGELOG entry. \nYou can find it at [CHANGELOG.md](https://github.com/ualbertalib/pushmi_pullyu/blob/master/CHANGELOG.md).", sticky: false)
 end
 
 # Warn when there is a big PR

--- a/Dangerfile
+++ b/Dangerfile
@@ -16,8 +16,10 @@ warn('Please add a detailed summary in the description.') if github.pr_body.leng
 # Let people say that this isn't worth a CHANGELOG entry in the PR if they choose
 declared_trivial = (github.pr_title + github.pr_body).include?('#trivial') || !has_app_changes
 
-if !git.modified_files.include?("CHANGELOG.md") && !declared_trivial
-  fail("Please include a CHANGELOG entry. \nYou can find it at [CHANGELOG.md](https://github.com/ualbertalib/pushmi_pullyu/blob/master/CHANGELOG.md).", sticky: false)
+if !git.modified_files.include?('CHANGELOG.md') && !declared_trivial
+  error_message = "Please include a CHANGELOG entry. \nYou can find it at " \
+                  '[CHANGELOG.md](https://github.com/ualbertalib/pushmi_pullyu/blob/master/CHANGELOG.md).'
+  fail(error_message, sticky: false)
 end
 
 # Warn when there is a big PR

--- a/Dangerfile
+++ b/Dangerfile
@@ -17,7 +17,7 @@ warn('Please add a detailed summary in the description.') if github.pr_body.leng
 declared_trivial = (github.pr_title + github.pr_body).include?('#trivial') || !has_app_changes
 
 if !git.modified_files.include?('CHANGELOG.md') && !declared_trivial
-  raise("Please include a CHANGELOG entry. \nYou can find it at " \
+  fail("Please include a CHANGELOG entry. \nYou can find it at " \
     '[CHANGELOG.md](https://github.com/ualbertalib/jupiter/blob/master/CHANGELOG.md).', sticky: false)
 end
 


### PR DESCRIPTION
## Context

Rubocop complains about using fail in Dangerfile and insists on using raise instead. However, danger uses fail with the sticky flag to specify how to treat the error. See https://danger.systems/reference.html

## What's New

Have rubocop ignore Dangerfile