### PR TITLE
Fix dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and releases in PushmiPullyu adheres to [Semantic Versioning](https://semver.org
 
 ## [Unreleased]
 
+- Fix dependency declaration for UUID gem
+
 ## [2.0.0] - 2020-12-14
 
 ### Removed

--- a/lib/pushmi_pullyu/version.rb
+++ b/lib/pushmi_pullyu/version.rb
@@ -1,3 +1,3 @@
 module PushmiPullyu
-  VERSION = '2.0.0'.freeze
+  VERSION = '2.0.1'.freeze
 end

--- a/pushmi_pullyu.gemspec
+++ b/pushmi_pullyu.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'redis', '>= 3.3', '< 5.0'
   spec.add_runtime_dependency 'rest-client', '>= 1.8', '< 3.0'
   spec.add_runtime_dependency 'rollbar', '>= 2.18', '< 4.0'
+  spec.add_runtime_dependency 'uuid', '~> 2.3.9'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'coveralls', '~> 0.8'
@@ -44,7 +45,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 0.51'
   spec.add_development_dependency 'rubocop-rspec', '~> 1.10'
   spec.add_development_dependency 'timecop', '~> 0.8'
-  spec.add_development_dependency 'uuid', '~> 2.3.9'
   spec.add_development_dependency 'vcr', '~> 5.0'
   spec.add_development_dependency 'webmock', '~> 3.3'
 end


### PR DESCRIPTION
## Context

Henry noticed when trying to take this to prod that it won't boot because we `require 'uuid'` for core functionality but accidentally declared it as a development dependency only rather than a runtime dep.

## What's New

Change UUID to a runtime dependency, and bumped the version to 2.0.1 since we already pushed 2.0.0 to rubygems with the bad spec.