### PR TITLE
Use read-only token for Danger

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,7 +25,7 @@ jobs:
       run: bundle exec rubocop --parallel
     - name: Run Danger
       env:
-        DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
+        DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: bundle exec danger
     - name: Run tests
       run: bundle exec rake spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and releases in PushmiPullyu adheres to [Semantic Versioning](https://semver.org
 
 ## [Unreleased]
 
+- Changed Danger token in Github Actions
+
 ## [2.0.2] - 2021-11-22
 
 - Fix authentication bug when using ssl 


### PR DESCRIPTION
## Context

> Starting March 1st, 2021 workflow runs that are triggered by Dependabot from push, pull_request, pull_request_review, or pull_request_review_comment events will be treated as if they were opened from a repository fork. This means they will receive a read-only GITHUB_TOKEN and will not have access to any secrets available in the repository.

Related to https://github.com/ualbertalib/jupiter/issues/2282

## What's New

Changed Danger github action to use the read-only [GITHUB_TOKEN](https://docs.github.com/en/actions/reference/authentication-in-a-workflow) and the GithubActions bot.