### PR TITLE
Remove pg dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and releases in PushmiPullyu adheres to [Semantic Versioning](https://semver.org
 
 - Fix authentication bug when using ssl 
 - bump rubocop and rubocop-rspec
+- remove pg dependency
 
 ## [2.0.1] - 2021-02-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,12 @@ and releases in PushmiPullyu adheres to [Semantic Versioning](https://semver.org
 
 ## [Unreleased]
 
+- remove pg dependency
+
 ## [2.0.2] - 2021-11-22
 
 - Fix authentication bug when using ssl 
 - bump rubocop and rubocop-rspec
-- remove pg dependency
 
 ## [2.0.1] - 2021-02-02
 

--- a/examples/pushmi_pullyu.yml
+++ b/examples/pushmi_pullyu.yml
@@ -21,9 +21,6 @@ minimum_age: 0
 redis:
   url: redis://localhost:6379
 
-database:
-  url: postgresql://jupiter:mysecretpassword@127.0.0.1/jupiter_development
-
 #parameters project_name and project_domain_name are required only for keystone v3 authentication
 swift:
   tenant: tester

--- a/lib/pushmi_pullyu.rb
+++ b/lib/pushmi_pullyu.rb
@@ -40,12 +40,6 @@ module PushmiPullyu
     },
     rollbar: {
     },
-    database: {
-      encoding: 'utf8',
-      pool: ENV['RAILS_MAX_THREADS'] || 5,
-      url: ENV['DATABASE_URL'] || ENV['JUPITER_DATABASE_URL'] || 'postgresql://jupiter:mysecretpassword@127.0.0.1',
-      database: 'jupiter_development'
-    },
     jupiter: {
       user: ENV['JUPITER_USER'],
       api_key: ENV['JUPITER_API_KEY'],

--- a/pushmi_pullyu.gemspec
+++ b/pushmi_pullyu.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'daemons', '~> 1.2', '>= 1.2.4'
   spec.add_runtime_dependency 'minitar', '~> 0.7'
   spec.add_runtime_dependency 'openstack', '~> 3.3', '>= 3.3.10'
-  spec.add_runtime_dependency 'pg', '>= 1.0', '< 1.2'
   spec.add_runtime_dependency 'rdf', '>= 1.99', '< 4.0'
   spec.add_runtime_dependency 'rdf-n3', '>= 1.99', '< 4.0'
   spec.add_runtime_dependency 'redis', '>= 3.3', '< 5.0'


### PR DESCRIPTION
## Context

This gem should be removed because a direct connection to a database is no longer needed. 

Related to #200 

## What's New

Removed gem dependency