### PR TITLE
Remove coveralls

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 
 [![Gem Version](https://badge.fury.io/rb/pushmi_pullyu.svg)](https://rubygems.org/gems/pushmi_pullyu)
 [![Github Build Status](https://github.com/ualbertalib/pushmi_pullyu/workflows/CI/badge.svg)](https://github.com/ualbertalib/pushmi_pullyu/actions)
-[![Coverage Status](https://coveralls.io/repos/github/ualbertalib/pushmi_pullyu/badge.svg?branch=master)](https://coveralls.io/github/ualbertalib/pushmi_pullyu?branch=master)
 
 PushmiPullyu is a Ruby application, running behind the firewall that protects our Swift environment.
 

--- a/pushmi_pullyu.gemspec
+++ b/pushmi_pullyu.gemspec
@@ -35,7 +35,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'uuid', '~> 2.3.9'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
-  spec.add_development_dependency 'coveralls', '~> 0.8'
   spec.add_development_dependency 'danger', '~> 8.0'
   spec.add_development_dependency 'pry', '~> 0.10', '>= 0.10.4'
   spec.add_development_dependency 'pry-byebug', '~> 3.6'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,3 @@
-require 'coveralls'
-Coveralls.wear!
-
 require 'bundler/setup'
 require 'pushmi_pullyu'
 require 'pry'


### PR DESCRIPTION
## Context
```
[Coveralls] Submitting to https://coveralls.io/api/v1
Coveralls encountered an exception:
OpenSSL::SSL::SSLError
SSL_connect returned=1 errno=0 state=error: no protocols available
```
Something has changed since November 2021.  I guess we remove it.

## What's New

Remove coveralls