### PR TITLE
Bump CHANGELOG and VERSION for 2.0.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and releases in PushmiPullyu adheres to [Semantic Versioning](https://semver.org
 
 ## [Unreleased]
 
+## [2.0.3] - 2022-04-28
+
 - Changed Danger token in Github Actions
 - remove pg dependency
 - unblock CI (rubocop and coveralls)

--- a/lib/pushmi_pullyu/version.rb
+++ b/lib/pushmi_pullyu/version.rb
@@ -1,3 +1,3 @@
 module PushmiPullyu
-  VERSION = '2.0.2'.freeze
+  VERSION = '2.0.3'.freeze
 end


### PR DESCRIPTION
## Context

We want to release a new version which includes the json logging so that we can upgrade the version of Ruby.

## What's New

Bumping version and changelog to 2.0.3