### PR TITLE
Fix/re add item id after failed deposit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and releases in PushmiPullyu adheres to [Semantic Versioning](https://semver.org
 
 - Fix issue with temporary work files not being deleted after a failed swift deposit [#242](https://github.com/ualbertalib/pushmi_pullyu/issues/242)
 - Bump to Ruby 2.7
+- Fix issue with entity information consumed even after failed deposit [#232](https://github.com/ualbertalib/pushmi_pullyu/issues/232)
 
 ## [2.0.3] - 2022-04-28
 

--- a/lib/pushmi_pullyu/aip.rb
+++ b/lib/pushmi_pullyu/aip.rb
@@ -6,8 +6,8 @@ module PushmiPullyu::AIP
   module_function
 
   def create(entity)
-    raise EntityInvalid if entity.nil? ||
-                           UUID.validate(entity[:uuid]) != true ||
+    raise EntityInvalid if entity.blank? ||
+                           UUID.validate(entity[:uuid]).blank? ||
                            entity[:type].blank?
 
     aip_directory = "#{PushmiPullyu.options[:workdir]}/#{entity[:uuid]}"

--- a/lib/pushmi_pullyu/cli.rb
+++ b/lib/pushmi_pullyu/cli.rb
@@ -183,8 +183,8 @@ class PushmiPullyu::CLI
 
   def run_preservation_cycle
     entity_json = queue.wait_next_item
-    # jupiter is submitting the entries to reddis in a hash format using fat arrows. We need to change them to clons in
-    # order to parse them corretrly from json
+    # jupiter is submitting the entries to reddis in a hash format using fat arrows. We need to change them to colons in
+    # order to parse them correctly from json
     entity = JSON.parse(entity_json.gsub('=>', ':'), { symbolize_names: true })
     return unless entity[:type].present? && entity[:uuid].present?
 

--- a/lib/pushmi_pullyu/preservation_queue.rb
+++ b/lib/pushmi_pullyu/preservation_queue.rb
@@ -68,6 +68,12 @@ class PushmiPullyu::PreservationQueue
     end
   end
 
+  def add_entity_json(entity_json)
+    @redis.with do |connection|
+      connection.zadd @queue_name, Time.now.to_f, entity_json
+    end
+  end
+
   protected
 
   def connected?

--- a/spec/fixtures/config_wrong_swift.yml
+++ b/spec/fixtures/config_wrong_swift.yml
@@ -1,0 +1,21 @@
+# Dummy sample file for testing parsing of configuration file into PushmiPullyu
+
+aip_version: 'lightaip-2.0'
+debug: true
+logdir: tmp/spec/log
+monitor: false
+piddir: tmp/spec/pids
+workdir: tmp/spec/work
+process_name: test_pushmi_pullyu
+minimum_age: 1
+queue_name: test:pmpy_queue
+rollbar:
+  token: 'abc123xyz'
+  proxy_host: 'your_proxy_url'
+  proxy_port: '80'
+swift:
+  auth_url: http://127.0.0.1:8080/auth/v1.0
+  password: 'wrong_password'
+jupiter:
+  user: 'ditech@ualberta.ca'
+  api_key: 'wrong_api_key'


### PR DESCRIPTION
## Context

Entity uuid, and type information is consumed from the redis queue, and it is not re-added on failed deposit, loosing track of the entity for a future deposit.

Related to #232 

## What's New

Added the entity information back to the redis queue on a StandardError exception and cleaned up exception handling on the ``run_preservation_cycle`` method.