### PR TITLE
Wip add community and collection to aips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and releases in PushmiPullyu adheres to [Semantic Versioning](https://semver.org
 ## [Unreleased]
 
 - Add rescue block to catch exceptions while waiting for next item [#280](https://github.com/ualbertalib/pushmi_pullyu/issues/280)
-
+- Add logic to fetch new community and collection information from jupiter and create their AIPS. [#255](https://github.com/ualbertalib/pushmi_pullyu/issues/255)
+- Bump git from 1.9.1 to 1.13.0
 ## [2.0.4] - 2022-11-22
 
 - Fix issue with temporary work files not being deleted after a failed swift deposit [#242](https://github.com/ualbertalib/pushmi_pullyu/issues/242)

--- a/lib/pushmi_pullyu/aip/downloader.rb
+++ b/lib/pushmi_pullyu/aip/downloader.rb
@@ -199,7 +199,7 @@ class PushmiPullyu::AIP::Downloader
       main_object_remote: object_uri,
       main_object_local: "#{aip_dirs[:metadata]}/object_metadata.n3",
       file_sets_remote: "#{object_uri}/filesets",
-      # This directory needs to be created before we can dowloand the file order information
+      # This directory needs to be created before we can downloaded the file order information
       file_sets_directory_local: "#{@aip_directory}/data/objects/metadata/files_metadata",
       file_sets_local: "#{@aip_directory}/data/objects/metadata/files_metadata/file_order.xml",
       # This is downloaded for processing but not saved

--- a/lib/pushmi_pullyu/aip/downloader.rb
+++ b/lib/pushmi_pullyu/aip/downloader.rb
@@ -37,8 +37,9 @@ class PushmiPullyu::AIP::Downloader
                      object_aip_paths[:main_object_local])
 
     # Communities and collections do not have their own files.
-    return if (@entity[:type] == 'collections') || (@entity[:type] == 'communities')
+    return unless can_have_files?
 
+    FileUtils.mkdir_p(object_aip_paths[:file_sets_directory_local])
     download_and_log(object_aip_paths[:file_sets_remote],
                      object_aip_paths[:file_sets_local])
 
@@ -143,25 +144,26 @@ class PushmiPullyu::AIP::Downloader
     PushmiPullyu::Logging.log_aip_activity(@aip_directory, message)
   end
 
+  def can_have_files?
+    @entity[:type] == 'items' || @entity[:type] == 'theses'
+  end
+
   ### Directories
 
   def aip_dirs
     @aip_dirs ||= {
       objects: "#{@aip_directory}/data/objects",
       metadata: "#{@aip_directory}/data/objects/metadata",
-      files: "#{@aip_directory}/data/objects/files",
-      files_metadata: "#{@aip_directory}/data/objects/metadata/files_metadata",
-      logs: "#{@aip_directory}/data/logs",
-      file_logs: "#{@aip_directory}/data/logs/files_logs"
+      logs: "#{@aip_directory}/data/logs"
     }
   end
 
   def file_set_dirs(file_set_uuid)
     @file_set_dirs ||= {}
     @file_set_dirs[file_set_uuid] ||= {
-      metadata: "#{aip_dirs[:files_metadata]}/#{file_set_uuid}",
-      files: "#{aip_dirs[:files]}/#{file_set_uuid}",
-      logs: "#{aip_dirs[:file_logs]}/#{file_set_uuid}"
+      files: "#{@aip_directory}/data/objects/files/#{file_set_uuid}",
+      logs: "#{@aip_directory}/data/logs/files_logs/#{file_set_uuid}",
+      metadata: "#{@aip_directory}/data/objects/metadata/files_metadata/#{file_set_uuid}"
     }
   end
 
@@ -197,7 +199,9 @@ class PushmiPullyu::AIP::Downloader
       main_object_remote: object_uri,
       main_object_local: "#{aip_dirs[:metadata]}/object_metadata.n3",
       file_sets_remote: "#{object_uri}/filesets",
-      file_sets_local: "#{aip_dirs[:files_metadata]}/file_order.xml",
+      # This directory needs to be created before we can dowloand the file order information
+      file_sets_directory_local: "#{@aip_directory}/data/objects/metadata/files_metadata",
+      file_sets_local: "#{@aip_directory}/data/objects/metadata/files_metadata/file_order.xml",
       # This is downloaded for processing but not saved
       file_paths_remote: "#{object_uri}/file_paths"
     }.freeze

--- a/lib/pushmi_pullyu/aip/downloader.rb
+++ b/lib/pushmi_pullyu/aip/downloader.rb
@@ -35,6 +35,10 @@ class PushmiPullyu::AIP::Downloader
     # Main object metadata
     download_and_log(object_aip_paths[:main_object_remote],
                      object_aip_paths[:main_object_local])
+
+    # Communities and collections do not have their own files.
+    return if (@entity[:type] == 'collections') || (@entity[:type] == 'communities')
+
     download_and_log(object_aip_paths[:file_sets_remote],
                      object_aip_paths[:file_sets_local])
 

--- a/spec/support/http_cache/vcr/aip_downloader_collection_run.yml
+++ b/spec/support/http_cache/vcr/aip_downloader_collection_run.yml
@@ -1,0 +1,131 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://era.lvh.me:3000/auth/system
+    body:
+      encoding: US-ASCII
+      string: email=ditech%40ualberta.ca&api_key=3eeb395e-63b7-11ea-bc55-0242ac130003
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - text/html
+      Cache-Control:
+      - no-cache
+      Content-Security-Policy:
+      - 'default-src ''self'' https:; font-src ''self'' https: data:; img-src ''self''
+        https: data: analytics.library.ualberta.ca www.google-analytics.com; object-src
+        ''none''; script-src ''unsafe-inline'' ''self'' https: analytics.library.ualberta.ca
+        www.google-analytics.com www.googletagmanager.com; style-src ''unsafe-inline''
+        ''self'' https:; connect-src ''self'' https: http://localhost:3035 ws://localhost:3035'
+      Set-Cookie:
+      - _jupiter_session=He%2B%2Bprk8TYa%2FTuGIHTj8pk0SGEbDInKVAlwaGWPK18XMfOyFwWDk2yQu2zmxhLXzpPZLaosfCgmAon9A7VP%2FDPlJdRHwFAktThioly5sBUIS%2BnO5FrnzuvhwDyEiJ7urHPdbwR45%2FtHoJFlYcXyLAysmqcQUttjG9x3FuN2obDEh7PB3rliWHdxl0yWDl1moP8gShfuFLXw%3D--V7fQ1sYj5RP33Xfd--I41kr8U3IPLmuS3n6iBrbA%3D%3D;
+        path=/; HttpOnly; SameSite=Lax
+      X-Request-Id:
+      - 29c4a8df-336b-497b-8715-4b45e4c7d933
+      X-Runtime:
+      - '0.248701'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: null
+  recorded_at: Wed, 18 Jan 2023 20:49:16 GMT
+- request:
+    method: get
+    uri: http://era.lvh.me:3000/aip/v1/collections/7e6cfffd-3c9a-44b6-a5d1-67fc0e2f1c43
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Cookie:
+      - _jupiter_session=He%2B%2Bprk8TYa%2FTuGIHTj8pk0SGEbDInKVAlwaGWPK18XMfOyFwWDk2yQu2zmxhLXzpPZLaosfCgmAon9A7VP%2FDPlJdRHwFAktThioly5sBUIS%2BnO5FrnzuvhwDyEiJ7urHPdbwR45%2FtHoJFlYcXyLAysmqcQUttjG9x3FuN2obDEh7PB3rliWHdxl0yWDl1moP8gShfuFLXw%3D--V7fQ1sYj5RP33Xfd--I41kr8U3IPLmuS3n6iBrbA%3D%3D;
+        path=/; HttpOnly; SameSite=Lax
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - text/plain; charset=utf-8
+      Etag:
+      - W/"99b520b2d9f0093ccd9d79edf41e7d7e"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self'' https:; font-src ''self'' https: data:; img-src ''self''
+        https: data: analytics.library.ualberta.ca www.google-analytics.com; object-src
+        ''none''; script-src ''unsafe-inline'' ''self'' https: analytics.library.ualberta.ca
+        www.google-analytics.com www.googletagmanager.com; style-src ''unsafe-inline''
+        ''self'' https:; connect-src ''self'' https: http://localhost:3035 ws://localhost:3035'
+      Set-Cookie:
+      - _jupiter_session=zHCfzL5g%2BKmT2ehYOkOvdqvsaDRpzo5V69Ax%2FvfP1RkaLUTLYnqa3g%2Fsxk%2BKJSTZPkpzDal10hAC%2FjyYNBxS%2FKkozf0nl%2BgI2L4zfRC77dmop%2BosZI9HXOrr6dHsjgEYnavD56qdgf6DlyHfJ7FhVTFwdHsCo5nGdxExTpjXPEqOElS%2Bz%2FdPlSB1DCOxra1mkPQPqzD5PFycXF0n3dysxKVQQUkD0DBdveJdijEQYsMDpH%2F287D9D1liYVTzl0wwJRrl6GZkOxMG4NmF783sya89r1K0C12dMrtdEOv5%2FlKx32DMYXRJyXsxOgvb8tGwMc6OdVDA9cwIqt8Q8QikyEQ15JjGdYKY--T8oMmVUTjhoOXPZe--xwa7x9NIbg7ktSlbC2iOfA%3D%3D;
+        path=/; HttpOnly; SameSite=Lax
+      X-Request-Id:
+      - d8ead5e1-f47a-46ec-bd47-1e1f9b88d553
+      X-Runtime:
+      - '0.026209'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        @prefix dc: <http://purl.org/dc/terms/> .
+        @prefix pcdm: <http://pcdm.org/models#> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        <http://era.lvh.me:3000/aip/v1/collections/7e6cfffd-3c9a-44b6-a5d1-67fc0e2f1c43> a pcdm:Collection;
+            dc:title "New collection";
+            dc:description "";
+            pcdm:memberOf "7c787de9-a33b-469e-8786-ba002b5ed66f";
+            dc:accessRights "http://terms.library.ualberta.ca/public";
+            dc:created "2023-01-12T22:22:12.828Z"^^xsd:dateTime;
+            <http://terms.library.ualberta.ca/recordCreatedInJupiter> "2023-01-12T22:22:12.814Z"^^xsd:dateTime;
+            <http://terms.library.ualberta.ca/restrictedCollection> false .
+    http_version: null
+  recorded_at: Wed, 18 Jan 2023 20:49:16 GMT
+recorded_with: VCR 5.1.0

--- a/spec/support/http_cache/vcr/aip_downloader_community_run.yml
+++ b/spec/support/http_cache/vcr/aip_downloader_community_run.yml
@@ -1,0 +1,128 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://era.lvh.me:3000/auth/system
+    body:
+      encoding: US-ASCII
+      string: email=ditech%40ualberta.ca&api_key=3eeb395e-63b7-11ea-bc55-0242ac130003
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - text/html
+      Cache-Control:
+      - no-cache
+      Content-Security-Policy:
+      - 'default-src ''self'' https:; font-src ''self'' https: data:; img-src ''self''
+        https: data: analytics.library.ualberta.ca www.google-analytics.com; object-src
+        ''none''; script-src ''unsafe-inline'' ''self'' https: analytics.library.ualberta.ca
+        www.google-analytics.com www.googletagmanager.com; style-src ''unsafe-inline''
+        ''self'' https:; connect-src ''self'' https: http://localhost:3035 ws://localhost:3035'
+      Set-Cookie:
+      - _jupiter_session=0MSY%2FJ%2F0B3x2d0QAsPY%2FsFfPoAGNp45RLL6LpcqiyISFSxckYJqKRxw%2FJ3%2BQzCXPdyh%2FjOP0yp6A38u0ukx5iGWaF%2BkNsksK%2Bxl%2B5hhbTG4vB2jy7CLTP1jKizN1p%2FVwYkN4q%2FLd6n2AOtq7lLeawLu%2BF6kgXe5HSSVwRdc7xils64G9YQkFdfeBoUBDrh2hACSQT5ugbUU%3D--sf%2BkUMT6z5aFlhVH--IlMecHTAehg6InuZStcp2w%3D%3D;
+        path=/; HttpOnly; SameSite=Lax
+      X-Request-Id:
+      - 7738a1b8-0cf3-4395-bb94-f550e66e23d1
+      X-Runtime:
+      - '0.246532'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: null
+  recorded_at: Tue, 17 Jan 2023 21:59:15 GMT
+- request:
+    method: get
+    uri: http://era.lvh.me:3000/aip/v1/communities/7c787de9-a33b-469e-8786-ba002b5ed66f
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Cookie:
+      - _jupiter_session=0MSY%2FJ%2F0B3x2d0QAsPY%2FsFfPoAGNp45RLL6LpcqiyISFSxckYJqKRxw%2FJ3%2BQzCXPdyh%2FjOP0yp6A38u0ukx5iGWaF%2BkNsksK%2Bxl%2B5hhbTG4vB2jy7CLTP1jKizN1p%2FVwYkN4q%2FLd6n2AOtq7lLeawLu%2BF6kgXe5HSSVwRdc7xils64G9YQkFdfeBoUBDrh2hACSQT5ugbUU%3D--sf%2BkUMT6z5aFlhVH--IlMecHTAehg6InuZStcp2w%3D%3D;
+        path=/; HttpOnly; SameSite=Lax
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - text/plain; charset=utf-8
+      Etag:
+      - W/"52f6137916d8bb9ae95863c2decab3bc"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Security-Policy:
+      - 'default-src ''self'' https:; font-src ''self'' https: data:; img-src ''self''
+        https: data: analytics.library.ualberta.ca www.google-analytics.com; object-src
+        ''none''; script-src ''unsafe-inline'' ''self'' https: analytics.library.ualberta.ca
+        www.google-analytics.com www.googletagmanager.com; style-src ''unsafe-inline''
+        ''self'' https:; connect-src ''self'' https: http://localhost:3035 ws://localhost:3035'
+      Set-Cookie:
+      - _jupiter_session=h7hVzHE61ZgLmmB%2B4Ce2HJszff%2FbQVDmqsOYvWG30Q8HaHDQYJgXmxUtb8%2Bp8atlpED6Oc5wMhJ02IRzBfxWjrP13x%2BMbq3VzTXeVrIsr7sKIc7tq3MwBjzi0o5DKpG67d0TEucw71ZYT5eAJuShsbBjCk2t%2Bp003pGlVkWkmjS%2B3gmCG1%2FInTqwJ4VLrVzm8FLIeS9we9%2BbDJccErlNRQsEbOeoaxo0EcmPOaycmMYTwlvRQwkePIWT6salnVMy5C3ruWavF1oQW2dmCy%2FZpkZQEk%2B2g46O2YBUJ9%2BqodBa9hy%2BwIQDDC6fKeVkLrxJ3DoNPIb4ZSUfKJBnu7q3o20PjoabgaJK--7O3%2BVHkwC%2BQmhBwp--M8UbDK9NvyRdUWni9F4hFA%3D%3D;
+        path=/; HttpOnly; SameSite=Lax
+      X-Request-Id:
+      - c0da1e3f-54dd-4ade-b5b1-1315dbf4ad09
+      X-Runtime:
+      - '0.027858'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        @prefix dc: <http://purl.org/dc/terms/> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        <http://era.lvh.me:3000/aip/v1/communities/7c787de9-a33b-469e-8786-ba002b5ed66f> a <http://terms.library.ualberta.ca/Community>;
+            dc:title "Special reports about dogs";
+            dc:description "Repudiandae occaecati et pariatur non aut debitis temporibus voluptatem quia modi accusantium ab dolorum magni voluptatem autem provident consequatur iure";
+            dc:accessRights "http://terms.library.ualberta.ca/public";
+            dc:created "2022-08-24T19:23:15.445Z"^^xsd:dateTime;
+            <http://terms.library.ualberta.ca/recordCreatedInJupiter> "2022-08-24T19:23:15.440Z"^^xsd:dateTime .
+    http_version: null
+  recorded_at: Tue, 17 Jan 2023 21:59:15 GMT
+recorded_with: VCR 5.1.0

--- a/spec/support/http_cache/vcr/aip_downloader_run.yml
+++ b/spec/support/http_cache/vcr/aip_downloader_run.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://localhost:3000/auth/system
+    uri: http://era.lvh.me:3000/auth/system
     body:
       encoding: US-ASCII
       string: email=ditech%40ualberta.ca&api_key=3eeb395e-63b7-11ea-bc55-0242ac130003
@@ -58,7 +58,7 @@ http_interactions:
   recorded_at: Fri, 07 Aug 2020 16:57:03 GMT
 - request:
     method: get
-    uri: http://localhost:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679
+    uri: http://era.lvh.me:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679
     body:
       encoding: US-ASCII
       string: ''
@@ -115,11 +115,11 @@ http_interactions:
         @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
         @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-        <http://localhost:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679> a pcdm:Object;
+        <http://era.lvh.me:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679> a pcdm:Object;
           dc:title "dcterms:title1$ Some Title for Item";
-          pcdm:hasMember <http://localhost:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets/4dfb117e-a1af-4c16-b6c9-9c4e2ee70981>,
-            <http://localhost:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets/5d043fa7-13b1-4367-a71b-dd13c37950bb>;
-          pcdm:memberOf <http://localhost:3000/aip/v1/collections/23afe4d2-bc7e-416e-8552-c44b7114bd77>;
+          pcdm:hasMember <http://era.lvh.me:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets/4dfb117e-a1af-4c16-b6c9-9c4e2ee70981>,
+            <http://era.lvh.me:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets/5d043fa7-13b1-4367-a71b-dd13c37950bb>;
+          pcdm:memberOf <http://era.lvh.me:3000/aip/v1/collections/23afe4d2-bc7e-416e-8552-c44b7114bd77>;
           <http://prismstandard.org/namespaces/basic/3.0/doi> "doi:10.7939/xxxxxxxxx";
           dc11:contributor "dc:contributor1$ Perez, Juan",
             "dc:contributor2$ Perez, Maria";
@@ -160,7 +160,7 @@ http_interactions:
   recorded_at: Fri, 07 Aug 2020 16:57:03 GMT
 - request:
     method: get
-    uri: http://localhost:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets
+    uri: http://era.lvh.me:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets
     body:
       encoding: US-ASCII
       string: ''
@@ -218,7 +218,7 @@ http_interactions:
   recorded_at: Fri, 07 Aug 2020 16:57:03 GMT
 - request:
     method: get
-    uri: http://localhost:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/file_paths
+    uri: http://era.lvh.me:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/file_paths
     body:
       encoding: US-ASCII
       string: ''
@@ -271,7 +271,7 @@ http_interactions:
   recorded_at: Fri, 07 Aug 2020 16:57:03 GMT
 - request:
     method: get
-    uri: http://localhost:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets/4dfb117e-a1af-4c16-b6c9-9c4e2ee70981/fixity
+    uri: http://era.lvh.me:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets/4dfb117e-a1af-4c16-b6c9-9c4e2ee70981/fixity
     body:
       encoding: US-ASCII
       string: ''
@@ -324,10 +324,10 @@ http_interactions:
         @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
         @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-        <http://localhost:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets/4dfb117e-a1af-4c16-b6c9-9c4e2ee70981> premis:hasFixity <http://localhost:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets/4dfb117e-a1af-4c16-b6c9-9c4e2ee70981/fixity>;
+        <http://era.lvh.me:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets/4dfb117e-a1af-4c16-b6c9-9c4e2ee70981> premis:hasFixity <http://era.lvh.me:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets/4dfb117e-a1af-4c16-b6c9-9c4e2ee70981/fixity>;
           premis:hasMessageDigest "GxpIjJsC4KnRoBKNjWnkJA==";
           premis:hasSize 12086 .
-        <http://localhost:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets/4dfb117e-a1af-4c16-b6c9-9c4e2ee70981/fixity> a premis:Fixity,
+        <http://era.lvh.me:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets/4dfb117e-a1af-4c16-b6c9-9c4e2ee70981/fixity> a premis:Fixity,
             premis:EventOutcomeDetail;
           premis:hasEventOutcome "SUCCESS";
           premis:hasMessageDigestAlgorithm "md5" .
@@ -335,7 +335,7 @@ http_interactions:
   recorded_at: Fri, 07 Aug 2020 16:57:03 GMT
 - request:
     method: get
-    uri: http://localhost:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets/4dfb117e-a1af-4c16-b6c9-9c4e2ee70981
+    uri: http://era.lvh.me:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets/4dfb117e-a1af-4c16-b6c9-9c4e2ee70981
     body:
       encoding: US-ASCII
       string: ''
@@ -393,13 +393,13 @@ http_interactions:
         @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
         @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-        <http://localhost:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets/4dfb117e-a1af-4c16-b6c9-9c4e2ee70981> a fcrepo4:Resource,
+        <http://era.lvh.me:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets/4dfb117e-a1af-4c16-b6c9-9c4e2ee70981> a fcrepo4:Resource,
             fcrepo4:Container,
             pcdm:Object,
             pcdm:File;
-          fcrepo4:hasFixityService <http://localhost:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets/fixity>;
-          fcrepo4:hasParent <http://localhost:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets/>;
-          pcdm:memberOf <http://localhost:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/collections/23afe4d2-bc7e-416e-8552-c44b7114bd77>;
+          fcrepo4:hasFixityService <http://era.lvh.me:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets/fixity>;
+          fcrepo4:hasParent <http://era.lvh.me:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets/>;
+          pcdm:memberOf <http://era.lvh.me:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/collections/23afe4d2-bc7e-416e-8552-c44b7114bd77>;
           dc:accessRights "http://terms.library.ualberta.ca/public";
           bibo:owner "admin@ualberta.ca";
           <http://terms.library.ualberta.ca/recordCreatedInJupiter> "2000-01-01T00:00:00.007Z"^^xsd:dateTime;
@@ -414,7 +414,7 @@ http_interactions:
   recorded_at: Fri, 07 Aug 2020 16:57:04 GMT
 - request:
     method: get
-    uri: http://localhost:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets/5d043fa7-13b1-4367-a71b-dd13c37950bb/fixity
+    uri: http://era.lvh.me:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets/5d043fa7-13b1-4367-a71b-dd13c37950bb/fixity
     body:
       encoding: US-ASCII
       string: ''
@@ -467,10 +467,10 @@ http_interactions:
         @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
         @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-        <http://localhost:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets/5d043fa7-13b1-4367-a71b-dd13c37950bb> premis:hasFixity <http://localhost:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets/5d043fa7-13b1-4367-a71b-dd13c37950bb/fixity>;
+        <http://era.lvh.me:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets/5d043fa7-13b1-4367-a71b-dd13c37950bb> premis:hasFixity <http://era.lvh.me:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets/5d043fa7-13b1-4367-a71b-dd13c37950bb/fixity>;
           premis:hasMessageDigest "/KC0nmafh5E2KWQKu7uCgQ==";
           premis:hasSize 136784 .
-        <http://localhost:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets/5d043fa7-13b1-4367-a71b-dd13c37950bb/fixity> a premis:Fixity,
+        <http://era.lvh.me:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets/5d043fa7-13b1-4367-a71b-dd13c37950bb/fixity> a premis:Fixity,
             premis:EventOutcomeDetail;
           premis:hasEventOutcome "SUCCESS";
           premis:hasMessageDigestAlgorithm "md5" .
@@ -478,7 +478,7 @@ http_interactions:
   recorded_at: Fri, 07 Aug 2020 16:57:04 GMT
 - request:
     method: get
-    uri: http://localhost:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets/5d043fa7-13b1-4367-a71b-dd13c37950bb
+    uri: http://era.lvh.me:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets/5d043fa7-13b1-4367-a71b-dd13c37950bb
     body:
       encoding: US-ASCII
       string: ''
@@ -536,13 +536,13 @@ http_interactions:
         @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
         @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-        <http://localhost:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets/5d043fa7-13b1-4367-a71b-dd13c37950bb> a fcrepo4:Resource,
+        <http://era.lvh.me:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets/5d043fa7-13b1-4367-a71b-dd13c37950bb> a fcrepo4:Resource,
             fcrepo4:Container,
             pcdm:Object,
             pcdm:File;
-          fcrepo4:hasFixityService <http://localhost:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets/fixity>;
-          fcrepo4:hasParent <http://localhost:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets/>;
-          pcdm:memberOf <http://localhost:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/collections/23afe4d2-bc7e-416e-8552-c44b7114bd77>;
+          fcrepo4:hasFixityService <http://era.lvh.me:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets/fixity>;
+          fcrepo4:hasParent <http://era.lvh.me:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/filesets/>;
+          pcdm:memberOf <http://era.lvh.me:3000/aip/v1/items/e2ec88e3-3266-4e95-8575-8b04fac2a679/collections/23afe4d2-bc7e-416e-8552-c44b7114bd77>;
           dc:accessRights "http://terms.library.ualberta.ca/public";
           bibo:owner "admin@ualberta.ca";
           <http://terms.library.ualberta.ca/recordCreatedInJupiter> "2000-01-01T00:00:00.007Z"^^xsd:dateTime;


### PR DESCRIPTION
## Context

Collection and community models were not being fetched for AIP creation and were not saved for preservation. The latest changes on jupiter will open up community and collection information. This change makes PMPY aware of this and will handle AIP creation.

Related to #255 

## What's New

Added logic to handle the creation of community and collection AIPs. These AIPs are very similar to the ones created for items and theses, with the exception that they will never include files.