### PR TITLE
Solve communication problems with jupiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and releases in PushmiPullyu adheres to [Semantic Versioning](https://semver.org
 
 ## [Unreleased]
 
+- Fix URI concatenation for jupiter's base url. [#309](https://github.com/ualbertalib/pushmi_pullyu/issues/309)
+
 ## [2.0.5] - 2023-02-17
 
 - Add rescue block to catch exceptions while waiting for next item [#280](https://github.com/ualbertalib/pushmi_pullyu/issues/280)

--- a/lib/pushmi_pullyu/aip/downloader.rb
+++ b/lib/pushmi_pullyu/aip/downloader.rb
@@ -86,7 +86,7 @@ class PushmiPullyu::AIP::Downloader
     @uri = URI.parse(PushmiPullyu.options[:jupiter][:jupiter_url])
     @http = Net::HTTP.new(@uri.host, @uri.port)
     @http.use_ssl = true if @uri.instance_of? URI::HTTPS
-    request = Net::HTTP::Post.new(URI.join(@uri,'/auth/system'))
+    request = Net::HTTP::Post.new(URI.join(@uri, '/auth/system'))
     request.set_form_data(
       email: PushmiPullyu.options[:jupiter][:user],
       api_key: PushmiPullyu.options[:jupiter][:api_key]

--- a/lib/pushmi_pullyu/aip/downloader.rb
+++ b/lib/pushmi_pullyu/aip/downloader.rb
@@ -86,7 +86,7 @@ class PushmiPullyu::AIP::Downloader
     @uri = URI.parse(PushmiPullyu.options[:jupiter][:jupiter_url])
     @http = Net::HTTP.new(@uri.host, @uri.port)
     @http.use_ssl = true if @uri.instance_of? URI::HTTPS
-    request = Net::HTTP::Post.new("#{@uri.request_uri}auth/system")
+    request = Net::HTTP::Post.new(URI.join(@uri,'/auth/system'))
     request.set_form_data(
       email: PushmiPullyu.options[:jupiter][:user],
       api_key: PushmiPullyu.options[:jupiter][:api_key]
@@ -102,7 +102,7 @@ class PushmiPullyu::AIP::Downloader
     log_downloading(remote, local)
 
     @uri = URI.parse(PushmiPullyu.options[:jupiter][:jupiter_url])
-    request = Net::HTTP::Get.new(@uri.request_uri + remote)
+    request = Net::HTTP::Get.new(URI.join(@uri, remote))
     # add previously stored cookies
     request['Cookie'] = @cookies
 
@@ -118,7 +118,7 @@ class PushmiPullyu::AIP::Downloader
   end
 
   def get_file_paths(url)
-    request = Net::HTTP::Get.new(@uri.request_uri + url)
+    request = Net::HTTP::Get.new(URI.join(@uri, url))
     # add previously stored cookies
     request['Cookie'] = @cookies
 

--- a/lib/pushmi_pullyu/cli.rb
+++ b/lib/pushmi_pullyu/cli.rb
@@ -220,7 +220,7 @@ class PushmiPullyu::CLI
     rescue StandardError => e
       begin
         queue.add_entity_in_timeframe(entity)
-      rescue MaxDepositAttemptsReached => e
+      rescue PushmiPullyu::PreservationQueue::MaxDepositAttemptsReached => e
         log_exception(e)
       end
 


### PR DESCRIPTION
## Context

Please describe any relevant motivation and context for these changes.

PMPY was not working in staging and all preservation attempts failed. PMPY could not find the full path to jupiter because it was using the URI request_uri which is the path after the localhost. If PMPY and jupiter are on different servers, this will not work.

Related to #297

## What's New

Changed use of method URI.request_uri to joining URI with new path.