### PR TITLE
Make sure the exception is in the scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and releases in PushmiPullyu adheres to [Semantic Versioning](https://semver.org
 
 ## [Unreleased]
 
+- Fix nil exception. [#314](https://github.com/ualbertalib/pushmi_pullyu/issues/314)
+
 ## [2.0.6] - 2023-03-17
 
 - Fix URI concatenation for jupiter's base url. [#309](https://github.com/ualbertalib/pushmi_pullyu/issues/309)

--- a/lib/pushmi_pullyu/cli.rb
+++ b/lib/pushmi_pullyu/cli.rb
@@ -224,14 +224,13 @@ class PushmiPullyu::CLI
         log_exception(e)
       end
 
-    # rubocop:disable Lint/RescueException
     # Something other than a StandardError exception means something happened which we were not expecting!
     # Make sure we log the problem
+    # rubocop:disable Lint/RescueException
     rescue Exception => e
+      log_exception(e)
       raise e
     # rubocop:enable Lint/RescueException
-    ensure
-      log_exception(e)
     end
   end
 

--- a/lib/pushmi_pullyu/cli.rb
+++ b/lib/pushmi_pullyu/cli.rb
@@ -230,8 +230,8 @@ class PushmiPullyu::CLI
     rescue Exception => e
       log_exception(e)
       raise e
-    # rubocop:enable Lint/RescueException
     end
+    # rubocop:enable Lint/RescueException
   end
 
   def run_tick_loop


### PR DESCRIPTION
## Context

We had recurring nil exceptions being logged. This was due to a basic error in the code scope.

Related to #314 

## What's New

Moved log method to the correct scope.