### PR TITLE
Add support for V3 authentication for Swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and releases in PushmiPullyu adheres to [Semantic Versioning](https://semver.org
 
 ## [Unreleased]
 
+- Add logic to perform authentication against the V3 Auth protocol
+
 ## [2.0.7] - 2023-09-13
 
 - Fix nil exception [#314](https://github.com/ualbertalib/pushmi_pullyu/issues/314)

--- a/examples/pushmi_pullyu.yml
+++ b/examples/pushmi_pullyu.yml
@@ -33,6 +33,9 @@ swift:
   project_name: demo
   project_domain_name: default
   container: ERA
+  # These 2 extra parameters are now required for keystone v3 authentication
+  auth_version: v3
+  user_domain: default
 
 rollbar:
   token: 'abc123xyz'

--- a/examples/pushmi_pullyu.yml
+++ b/examples/pushmi_pullyu.yml
@@ -32,7 +32,7 @@ swift:
   auth_url: http://localhost:8080/auth/v1.0
   project_name: demo
   project_domain_name: default
-  container: ERA
+  container: era
   # These 2 extra parameters are now required for keystone v3 authentication
   auth_version: v3
   user_domain: default

--- a/lib/pushmi_pullyu.rb
+++ b/lib/pushmi_pullyu.rb
@@ -39,8 +39,8 @@ module PushmiPullyu
       auth_url: 'http://localhost:8080/auth/v1.0',
       project_name: 'demo',
       project_domain_name: 'default',
-      container: 'ERA',
-      auth_version: 'v1',
+      container: 'era',
+      auth_version: 'v3',
       user_domain: 'default'
     },
     rollbar: {},

--- a/lib/pushmi_pullyu.rb
+++ b/lib/pushmi_pullyu.rb
@@ -39,7 +39,9 @@ module PushmiPullyu
       auth_url: 'http://localhost:8080/auth/v1.0',
       project_name: 'demo',
       project_domain_name: 'default',
-      container: 'ERA'
+      container: 'ERA',
+      auth_version: 'v1',
+      user_domain: 'default'
     },
     rollbar: {},
     # rubocop disable: Style/FetchEnvVar

--- a/lib/pushmi_pullyu/cli.rb
+++ b/lib/pushmi_pullyu/cli.rb
@@ -266,10 +266,12 @@ class PushmiPullyu::CLI
   def swift
     @swift ||= PushmiPullyu::SwiftDepositer.new(username: options[:swift][:username],
                                                 password: options[:swift][:password],
-                                                tenant: options[:swift][:tenant],
                                                 project_name: options[:swift][:project_name],
+                                                tenant: options[:swift][:tenant],
                                                 project_domain_name: options[:swift][:project_domain_name],
-                                                auth_url: options[:swift][:auth_url])
+                                                user_domain: options[:swift][:user_domain],
+                                                auth_url: options[:swift][:auth_url],
+                                                auth_version: options[:swift][:auth_version])
   end
 
   # On first call of shutdown, this will gracefully close the main run loop

--- a/lib/pushmi_pullyu/swift_depositer.rb
+++ b/lib/pushmi_pullyu/swift_depositer.rb
@@ -6,16 +6,24 @@ class PushmiPullyu::SwiftDepositer
   attr_reader :swift_connection
 
   def initialize(connection)
-    @swift_connection = OpenStack::Connection.create(
+    # Generic authentication parameters
+    swift_connection_parameters = {
       username: connection[:username],
       api_key: connection[:password],
-      auth_method: 'password',
       auth_url: connection[:auth_url],
       project_name: connection[:project_name],
-      project_domain_name: connection[:project_domain_name],
-      authtenant_name: connection[:tenant],
+      auth_method: 'password',
       service_type: 'object-store'
-    )
+    }
+
+    if connection[:auth_version] == 'v3'
+      swift_connection_parameters[:user_domain] = connection[:user_domain]
+    else
+      swift_connection_parameters[:project_domain_name] = connection[:project_domain_name]
+      swift_connection_parameters[:authtenant_name] = connection[:tenant]
+    end
+
+    @swift_connection = OpenStack::Connection.create(swift_connection_parameters)
   end
 
   def deposit_file(file_name, swift_container)

--- a/lib/pushmi_pullyu/swift_depositer.rb
+++ b/lib/pushmi_pullyu/swift_depositer.rb
@@ -18,7 +18,7 @@ class PushmiPullyu::SwiftDepositer
 
     if connection[:auth_version] == 'v3'
       swift_connection_parameters[:user_domain] = connection[:user_domain]
-    else
+    elsif connection[:auth_version] == 'v1'
       swift_connection_parameters[:project_domain_name] = connection[:project_domain_name]
       swift_connection_parameters[:authtenant_name] = connection[:tenant]
     end

--- a/spec/fixtures/config.yml
+++ b/spec/fixtures/config.yml
@@ -18,6 +18,8 @@ rollbar:
   proxy_port: '80'
 swift:
   auth_url: http://127.0.0.1:8080/auth/v1.0
+  auth_version: 'v1'
+  container: 'ERA'
 jupiter:
   user: 'ditech@ualberta.ca'
   api_key: '3eeb395e-63b7-11ea-bc55-0242ac130003'

--- a/spec/pushmi_pullyu/swift_depositer_spec.rb
+++ b/spec/pushmi_pullyu/swift_depositer_spec.rb
@@ -43,5 +43,25 @@ RSpec.describe PushmiPullyu::SwiftDepositer do
         end.to change { swift_depositer.swift_connection.container('ERA').count.to_i }.by(1)
       end
     end
+
+    it 'authenticates against v3' do
+      VCR.use_cassette('swift_auth_v3') do
+        swift_depositer = PushmiPullyu::SwiftDepositer.new(
+          username: 'era_olrc_user',
+          password: 'era_olrc_user_password',
+          auth_url: 'https://olrc2auth.scholarsportal.info/v3/',
+          user_domain: 'alberta',
+          container: 'era',
+          project_name: 'demo',
+          auth_method: 'password',
+          service_type: 'object-store',
+          auth_version: 'v3'
+        )
+        expect(swift_depositer).not_to be_nil
+        # rubocop:disable Layout/LineLength
+        expect(swift_depositer.swift_connection.connection.authtoken).to eq('gAAAAABl8hYAouKZJLkt8NDmuA2NjA1zOasGOAX-b2MfKpjiM_kf8sZHe42ipcs6Vb-57-aATajbTg54wIwhNhl2HKRfz5_rKfSJ0PnBQNFCVd4bKrdC0pHzoJMn9hkAa2tjBkqppBcMayvfqz-Ppxn0USnHw0z9zLLKDxGbRZwyhDJDhGOcIZg')
+        # rubocop:enable Layout/LineLength
+      end
+    end
   end
 end

--- a/spec/support/http_cache/vcr/swift_auth_v3.yml
+++ b/spec/support/http_cache/vcr/swift_auth_v3.yml
@@ -1,0 +1,66 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://olrc2auth.scholarsportal.info/v3/auth/tokens
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"era_olrc_user","password":"era_olrc_user_password","domain":{"name":"alberta"}}}}}}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Wed, 13 Mar 2024 21:09:20 GMT
+      Server:
+      - Apache/2.4.41 (Ubuntu)
+      Content-Length:
+      - '1886'
+      X-Subject-Token:
+      - gAAAAABl8hYAouKZJLkt8NDmuA2NjA1zOasGOAX-b2MfKpjiM_kf8sZHe42ipcs6Vb-57-aATajbTg54wIwhNhl2HKRfz5_rKfSJ0PnBQNFCVd4bKrdC0pHzoJMn9hkAa2tjBkqppBcMayvfqz-Ppxn0USnHw0z9zLLKDxGbRZwyhDJDhGOcIZg
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-cb9774f0-ca68-41ca-94a8-5c609484d89a
+      Content-Type:
+      - application/json
+      Strict-Transport-Security:
+      - max-age=15768000
+    body:
+      encoding: UTF-8
+      string: '{"token": {"methods": ["password"], "user": {"domain": {"id": "60033000eb9b493c821fe34be81330b9",
+        "name": "alberta"}, "id": "e422e226f1334b1aa36123b63756f3a4", "name": "era_olrc_user",
+        "password_expires_at": null}, "audit_ids": ["qjsTzr_SRE-kV3xcOycoEA"], "expires_at":
+        "2024-03-14T21:09:20.000000Z", "issued_at": "2024-03-13T21:09:20.000000Z",
+        "project": {"domain": {"id": "60033000eb9b493c821fe34be81330b9", "name": "alberta"},
+        "id": "94df3c9b19b94cb1b7226a2508f829fe", "name": "demo"}, "is_domain": false,
+        "roles": [{"id": "4aa402bf191f4386a255dc6fcf68ee1f", "name": "reader"}, {"id":
+        "6cec17d597684f8b802c8104edef4f1a", "name": "member"}], "catalog": [{"endpoints":
+        [{"id": "4106d3839f954125b11c04b74b0c8291", "interface": "admin", "region_id":
+        "RegionOne", "url": "http://lb.olrcdata.sp:5000/v3/", "region": "RegionOne"},
+        {"id": "60820abcda1540b28080a5a1b22b1978", "interface": "internal", "region_id":
+        "RegionOne", "url": "http://lb.olrcdata.sp:5000/v3/", "region": "RegionOne"},
+        {"id": "779f1fcc40e842e6815b4e8c4dd633e8", "interface": "public", "region_id":
+        "RegionOne", "url": "https://olrc2auth.scholarsportal.info/v3/", "region":
+        "RegionOne"}], "id": "8d38d27a36ac44b1af75cf576558825c", "type": "identity",
+        "name": "keystone"}, {"endpoints": [{"id": "407fe60111604028830faeb87d5e54d3",
+        "interface": "internal", "region_id": "RegionOne", "url": "http://lb.olrcdata.sp:8080/v1/AUTH_94df3c9b19b94cb1b7226a2508f829fe",
+        "region": "RegionOne"}, {"id": "cbc5239dbf1d41b8a5f3b3b21df40c37", "interface":
+        "public", "region_id": "RegionOne", "url": "https://olrc2.scholarsportal.info/v1/AUTH_94df3c9b19b94cb1b7226a2508f829fe",
+        "region": "RegionOne"}, {"id": "e1f3055570034d6c8492add7a315df88", "interface":
+        "admin", "region_id": "RegionOne", "url": "http://lb.olrcdata.sp:8080/v1",
+        "region": "RegionOne"}], "id": "cf170fa779df4e34bf4def2bea3bdecd", "type":
+        "object-store", "name": "swift"}]}}'
+    http_version: null
+  recorded_at: Wed, 13 Mar 2024 21:09:20 GMT
+recorded_with: VCR 5.1.0


### PR DESCRIPTION
This PR adds configuration options to create Swift depositer objects configured with V3 authentication.

This configuration will be used with the move to OLRC.

## Context

We are moving Swift destination from local to OLRC. This requires a different type of authentication. The rest of the behaviour stays the same.

Related to #349

## What's New

Adds configuration options and tests for authenticating on Openstack Swift servers with V3 authentication.