### PR TITLE
Add/more logging information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and releases in PushmiPullyu adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+ - Add more logging information [#433](https://github.com/ualbertalib/pushmi_pullyu/issues/433)
 
 ## [2.0.7] - 2023-09-13
 

--- a/lib/pushmi_pullyu/cli.rb
+++ b/lib/pushmi_pullyu/cli.rb
@@ -212,7 +212,7 @@ class PushmiPullyu::CLI
         # Push tarred AIP to swift API
         deposited_file = swift.deposit_file(aip_filename, options[:swift][:container])
         # Log successful preservation event to the log files
-        PushmiPullyu::Logging.log_preservation_event(deposited_file, aip_directory)
+        PushmiPullyu::Logging.log_preservation_success(deposited_file, aip_directory)
       end
     # An EntityInvalid expection means there is a problem with the entity information format so there is no point in
     # readding it to the queue as it will always fail

--- a/lib/pushmi_pullyu/logging.rb
+++ b/lib/pushmi_pullyu/logging.rb
@@ -43,10 +43,20 @@ module PushmiPullyu::Logging
       aip_logger.close
     end
 
-    def log_preservation_success(deposited_file, aip_directory)
+    def log_preservation_event(message, message_json)
       preservation_logger = Logger.new("#{PushmiPullyu.options[:logdir]}/preservation_events.log")
       preservation_json_logger = Logger.new("#{PushmiPullyu.options[:logdir]}/preservation_events.json")
 
+      logger.info(message)
+      preservation_logger.info(message)
+
+      preservation_logger.close
+
+      preservation_json_logger.info("#{message_json},")
+      preservation_json_logger.close
+    end
+
+    def log_preservation_success(deposited_file, aip_directory)
       message = "#{deposited_file.name} was successfully deposited into Swift Storage!\n" \
                 "Here are the details of this preservation event:\n" \
                 "\tUUID: '#{deposited_file.name}'\n" \
@@ -68,15 +78,64 @@ module PushmiPullyu::Logging
         end
       end
 
-      # Log to both the application log, and the preservation log file
-      logger.info(message)
-      preservation_logger.info(message)
+      log_preservation_event(message, preservation_success_to_json(deposited_file, aip_directory))
+    end
 
-      preservation_logger.close
+    def log_preservation_fail_and_retry(entity, retry_attempt, exception)
+      message = "#{entity[:type]} failed to be deposited and will try again.\n" \
+                "Here are the details of this preservation event:\n" \
+                "\t#{entity[:type]} uuid: #{entity[:uuid]}" \
+                "\tReadding to preservation queue with retry attempt: #{retry_attempt}\n" \
+                "\tError of tyoe: #{exception.type}\n" \
+                "\tError message: #{exception.message}\n"
 
-      message_json_str = preservation_event_to_json(deposited_file, aip_directory)
-      preservation_json_logger.info("#{message_json_str},")
-      preservation_json_logger.close
+      message_information = {
+        event_type: :fail_and_retry,
+        event_time: Time.now.to_s,
+        entity_type: entity[:type],
+        entity_uuid: entity[:uuid],
+        retry_attempt: retry_attempt,
+        error_type: exception.type,
+        error_message: exception.message
+      }
+
+      log_preservation_event(message, message_information.to_json)
+    end
+
+    def log_preservation_failure(entity, retry_attempt, exception)
+      message = "#{entity[:type]} failed to be deposited.\n" \
+                "Here are the details of this preservation event:\n" \
+                "\t#{entity[:type]} uuid: #{entity[:uuid]}" \
+                "\tRetry attempt: #{retry_attempt}\n"
+
+      message_information = {
+        event_type: :fail_and_retry,
+        event_time: Time.now.to_s,
+        entity_type: entity[:type],
+        entity_uuid: entity[:uuid],
+        retry_attempt: retry_attempt,
+        error_type: exception.type,
+        error_message: exception.message
+      }
+
+      log_preservation_event(message, message_information.to_json)
+    end
+
+    def log_preservation_attempt(entity, retry_attempt)
+      message = "#{entity[:type]} will attempt to be deposited.\n" \
+                "Here are the details of this preservation event:\n" \
+                "\t#{entity[:type]} uuid: #{entity[:uuid]}" \
+                "\tRetry attempt: #{retry_attempt}\n"
+
+      message_information = {
+        event_type: :attempt,
+        event_time: Time.now.to_s,
+        entity_type: entity[:type],
+        entity_uuid: entity[:uuid],
+        retry_attempt: retry_attempt
+      }
+
+      log_preservation_event(message, message_information.to_json)
     end
 
     ###
@@ -107,7 +166,7 @@ module PushmiPullyu::Logging
     # note:
     #   to parse, the prefix "I, ... INFO --:" in each line needs to be
     #   stripped using a bash command such as "sed"
-    def preservation_event_to_json(deposited_file, aip_directory)
+    def preservation_success_to_json(deposited_file, aip_directory)
       message = {}
 
       message['do_uuid'] = deposited_file.name.to_s

--- a/lib/pushmi_pullyu/logging.rb
+++ b/lib/pushmi_pullyu/logging.rb
@@ -91,7 +91,6 @@ module PushmiPullyu::Logging
         entity_type: entity[:type],
         entity_uuid: entity[:uuid],
         retry_attempt: retry_attempt,
-        error_type: exception.class.name,
         error_message: exception.message
       }
 
@@ -110,7 +109,6 @@ module PushmiPullyu::Logging
         entity_type: entity[:type],
         entity_uuid: entity[:uuid],
         retry_attempt: retry_attempt,
-        error_type: exception.class.name,
         error_message: exception.message
       }
 
@@ -169,7 +167,7 @@ module PushmiPullyu::Logging
       message['aip_deposited_at'] = deposited_file.last_modified.to_s
       message['aip_md5sum'] = deposited_file.etag.to_s
       message['aip_sha256'] = ''
-      message['aip_metadata'] = deposited_file.metadata.to_json
+      message['aip_metadata'] = deposited_file.metadata
 
       file_details = file_log_details(aip_directory)
 

--- a/lib/pushmi_pullyu/logging.rb
+++ b/lib/pushmi_pullyu/logging.rb
@@ -43,7 +43,7 @@ module PushmiPullyu::Logging
       aip_logger.close
     end
 
-    def log_preservation_event(deposited_file, aip_directory)
+    def log_preservation_success(deposited_file, aip_directory)
       preservation_logger = Logger.new("#{PushmiPullyu.options[:logdir]}/preservation_events.log")
       preservation_json_logger = Logger.new("#{PushmiPullyu.options[:logdir]}/preservation_events.json")
 

--- a/lib/pushmi_pullyu/preservation_queue.rb
+++ b/lib/pushmi_pullyu/preservation_queue.rb
@@ -70,6 +70,13 @@ class PushmiPullyu::PreservationQueue
     end
   end
 
+  def get_entity_ingestion_attempt(entity)
+    entity_attempts_key = "#{PushmiPullyu.options[:ingestion_prefix]}#{entity[:uuid]}"
+    @redis.with do |connection|
+      return connection.get entity_attempts_key
+    end
+  end
+
   def add_entity_in_timeframe(entity)
     entity_attempts_key = "#{PushmiPullyu.options[:ingestion_prefix]}#{entity[:uuid]}"
 

--- a/spec/integration/acceptance_spec.rb
+++ b/spec/integration/acceptance_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe 'Acceptance test', type: :feature do
         expect(deposited_file.metadata['promise']).to eql 'bronze'
 
         # Log successful preservation event to the log files
-        PushmiPullyu::Logging.log_preservation_event(deposited_file, aip_folder)
+        PushmiPullyu::Logging.log_preservation_success(deposited_file, aip_folder)
       end
     end
 

--- a/spec/integration/acceptance_spec.rb
+++ b/spec/integration/acceptance_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe 'Acceptance test', type: :feature do
 
     FileUtils.mkdir_p(workdir)
     FileUtils.mkdir_p(log_folder)
-
+    PushmiPullyu::Logging.initialize_loggers(events_target: "#{log_folder}/preservation_events.log",
+                                             json_target: "#{log_folder}/preservation_events.json")
     allow(PushmiPullyu::Logging.logger).to receive(:info)
   end
 
@@ -46,7 +47,6 @@ RSpec.describe 'Acceptance test', type: :feature do
     # Should not exist yet
     expect(File.exist?(aip_folder)).to be(false)
     expect(File.exist?(aip_file)).to be(false)
-    expect(File.exist?("#{log_folder}/preservation_events.log")).to be(false)
 
     # Download data from Jupiter, bag and tar AIP directory and cleanup after block code
     VCR.use_cassette('aip_download_and_swift_upload', erb:

--- a/spec/pushmi_pullyu/cli_spec.rb
+++ b/spec/pushmi_pullyu/cli_spec.rb
@@ -290,7 +290,7 @@ RSpec.describe PushmiPullyu::CLI do
         # expect((readded_entity_score.to_i - test_time).to_i).to eq 10
         cli.parse(['-C', 'spec/fixtures/config_wrong_swift.yml'])
         redis = Redis.new
-        entity = { uuid: '123e4567-e89b-12d3-a456-426614174000', type: 'items' }
+        entity = { uuid: 'e2ec88e3-3266-4e95-8575-8b04fac2a679', type: 'items' }
 
         start_time = Time.now - 10
         attempt_key = "#{PushmiPullyu.options[:ingestion_prefix]}#{entity[:uuid]}"
@@ -302,7 +302,7 @@ RSpec.describe PushmiPullyu::CLI do
             VCR.use_cassette('aip_download_and_swift_upload') do
               PushmiPullyu::Logging.logger.fatal!
               cli.send(:run_preservation_cycle)
-              PushmiPullyu::Logging.initialize_logger
+              PushmiPullyu::Logging.initialize_loggers
               time_now = Time.now.to_i
               _readded_entity, readded_entity_score = redis.zrange(PushmiPullyu.options[:queue_name],
                                                                    0, 0, with_scores: true).first
@@ -322,7 +322,7 @@ RSpec.describe PushmiPullyu::CLI do
       it 'makes sure an entities information is readded to redis when deposit fails' do
         cli.parse(['-C', 'spec/fixtures/config_wrong_swift.yml'])
         redis = Redis.new
-        entity = { uuid: '123e4567-e89b-12d3-a456-426614174000', type: 'items' }
+        entity = { uuid: 'e2ec88e3-3266-4e95-8575-8b04fac2a679', type: 'items' }
 
         redis.zadd(PushmiPullyu.options[:queue_name], 10, entity.to_json)
         redis.set("#{PushmiPullyu.options[:ingestion_prefix]}#{entity[:uuid]}", 0)
@@ -335,8 +335,8 @@ RSpec.describe PushmiPullyu::CLI do
           # and will re-add the original entity information back into the queue with a different score.
           # We know that we will be getting an error on this method so lets filter out the logs for this bit.
           PushmiPullyu::Logging.logger.fatal!
+          PushmiPullyu::Logging.initialize_loggers
           cli.send(:run_preservation_cycle)
-          PushmiPullyu::Logging.initialize_logger
           readded_entity, readded_entity_score = redis.zrange(PushmiPullyu.options[:queue_name],
                                                               0, 0, with_scores: true).first
           readded_attempt = redis.get("#{PushmiPullyu.options[:ingestion_prefix]}#{entity[:uuid]}")

--- a/spec/pushmi_pullyu/logging_spec.rb
+++ b/spec/pushmi_pullyu/logging_spec.rb
@@ -31,7 +31,13 @@ RSpec.describe PushmiPullyu::Logging do
   describe '.reopen' do
     let(:tmp_dir) { 'tmp/test_dir' }
     let(:logfile) { "#{tmp_dir}/pushmi_pullyu.log" }
-    let(:logger) { PushmiPullyu::Logging.initialize_logger(logfile) }
+    let(:log_events) { "#{tmp_dir}/events.log" }
+    let(:log_json) { "#{tmp_dir}/json.log" }
+    let(:logger) do
+      PushmiPullyu::Logging.initialize_loggers(log_target: logfile,
+                                               events_target: log_events,
+                                               json_target: log_json)
+    end
 
     before do
       FileUtils.mkdir_p(tmp_dir)
@@ -84,8 +90,19 @@ RSpec.describe PushmiPullyu::Logging do
     let(:tmp_log_dir) { 'tmp/logs' }
     let(:tmp_aip_dir) { 'tmp/test_aip_dir' }
 
+    before do
+      FileUtils.mkdir_p(tmp_aip_dir)
+    end
+
+    after do
+      FileUtils.rm_rf(tmp_aip_dir)
+    end
+
     it 'logs preservation event to both preservation log and application log' do
       FileUtils.mkdir_p(tmp_log_dir)
+      # Make sure we are initialize logger with expected file destinations and not default stdout destination
+      PushmiPullyu::Logging.initialize_loggers(events_target: "#{tmp_log_dir}/preservation_events.log",
+                                               json_target: "#{tmp_log_dir}/preservation_events.json")
       allow(PushmiPullyu::Logging.logger).to receive(:info)
       allow(PushmiPullyu).to receive(:options) { { logdir: tmp_log_dir } }
 
@@ -109,6 +126,27 @@ RSpec.describe PushmiPullyu::Logging do
       ).to include("#{deposited_file.name} was successfully deposited into Swift Storage!")
 
       FileUtils.rm_rf(tmp_log_dir)
+    end
+  end
+
+  # XXX Placeholder test to be filled in
+  describe '.log_preservation_attempt' do
+    it 'logs preservation attempts' do
+      expect(true).to be(false)
+    end
+  end
+
+  # XXX Placeholder test to be filled in
+  describe '.log_preservation_fail_and_retry' do
+    it 'logs preservation fail and retry' do
+      expect(true).to be(false)
+    end
+  end
+
+  # XXX Placeholder test to be filled in
+  describe '.log_preservation_failure' do
+    it 'logs preservation failure' do
+      expect(true).to be(false)
     end
   end
 

--- a/spec/pushmi_pullyu/logging_spec.rb
+++ b/spec/pushmi_pullyu/logging_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe PushmiPullyu::Logging do
     end
   end
 
-  describe '.log_preservation_event' do
+  describe '.log_preservation_success' do
     let(:tmp_log_dir) { 'tmp/logs' }
     let(:tmp_aip_dir) { 'tmp/test_aip_dir' }
 
@@ -100,7 +100,7 @@ RSpec.describe PushmiPullyu::Logging do
                     'project' => 'ERA' }
       )
 
-      PushmiPullyu::Logging.log_preservation_event(deposited_file, tmp_aip_dir)
+      PushmiPullyu::Logging.log_preservation_success(deposited_file, tmp_aip_dir)
 
       expect(File.exist?("#{tmp_log_dir}/preservation_events.log")).to be(true)
       expect(PushmiPullyu::Logging.logger).to have_received(:info).with(an_instance_of(String)).once


### PR DESCRIPTION
    WIP Add more preservation events to logs
    
    This work in progress adds more information about all logging events
    to get a better idea of the behavior on PMPY.
    
    Right now the preservation event loggers are initialized on startup
    instead of being instantiated every time there is a preservation event.
    
    All is done in the logger reader method. We could change it so the
    preservation loggers are instantiated on their access.
    
    3 placeholder tests need to be completed.