### PR TITLE
Fix problem with authentication token expiration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ PushmiPullyu is a Ruby application, whose primary job is to manage the flow of c
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and releases in PushmiPullyu adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+ - Refresh authentication token after it expires [#311](https://github.com/ualbertalib/pushmi_pullyu/issues/311)
+
 ## [2.1.2]
  - Simplify get entity code [#280](https://github.com/ualbertalib/pushmi_pullyu/issues/280)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     # swift auth -v -U test:tester -K testing -A http://localhost:8080/auth/v1.0
     # swift auth
     # swift post ERA
-    image: openstackswift/saio
+    # image: openstackswift/saio
+    # The previously used image was getting connection problems
+    image: openstackswift/saio:change_846891_latest
     ports:
       - '8080:8080'

--- a/lib/pushmi_pullyu/swift_depositer.rb
+++ b/lib/pushmi_pullyu/swift_depositer.rb
@@ -62,8 +62,7 @@ class PushmiPullyu::SwiftDepositer
       # and metadata as additional key/value string pairs in the hash
       headers = { 'etag' => checksum,
                   'content-type' => 'application/x-tar',
-                  'X-Auth-New-Token' => 'true'
-                }.merge(metadata)
+                  'X-Auth-New-Token' => 'true' }.merge(metadata)
       deposited_file = era_container.object(file_base_name)
       deposited_file.write(File.open(file_name), headers)
     else
@@ -71,8 +70,7 @@ class PushmiPullyu::SwiftDepositer
       headers = { etag: checksum,
                   content_type: 'application/x-tar',
                   metadata: metadata,
-                  'X-Auth-New-Token' => 'true'
-                 }
+                  'X-Auth-New-Token' => 'true' }
       deposited_file = era_container.create_object(file_base_name, headers, File.open(file_name))
     end
 

--- a/lib/pushmi_pullyu/swift_depositer.rb
+++ b/lib/pushmi_pullyu/swift_depositer.rb
@@ -2,10 +2,9 @@ require 'digest/md5'
 require 'openstack'
 class PushmiPullyu::SwiftDepositer
 
-  def initialize(connection, connection_wait_time: 10)
-    @connection_wait_time = connection_wait_time
+  def initialize(connection)
     # Generic authentication parameters
-    @swift_connection_parameters = {
+    swift_connection_parameters = {
       username: connection[:username],
       api_key: connection[:password],
       auth_url: connection[:auth_url],
@@ -19,28 +18,19 @@ class PushmiPullyu::SwiftDepositer
     }
 
     if connection[:auth_version] == 'v3'
-      @swift_connection_parameters[:user_domain] = connection[:user_domain]
+      swift_connection_parameters[:user_domain] = connection[:user_domain]
     elsif connection[:auth_version] == 'v1'
-      @swift_connection_parameters[:project_domain_name] = connection[:project_domain_name]
-      @swift_connection_parameters[:authtenant_name] = connection[:tenant]
+      swift_connection_parameters[:project_domain_name] = connection[:project_domain_name]
+      swift_connection_parameters[:authtenant_name] = connection[:tenant]
     end
 
-    establish_connection
+    @swift_connection = OpenStack::Connection.create(swift_connection_parameters)
   end
 
   def deposit_file(file_name, swift_container)
     file_base_name = File.basename(file_name, '.*')
     checksum = Digest::MD5.file(file_name).hexdigest
-    begin
-      era_container = @swift_connection.container(swift_container)
-    rescue OpenStack::Exception::ExpiredAuthToken => e
-      Rollbar.error(e)
-      logger.error(e)
-      # PMPY needs to be able to communicate with swift to continue working
-      sleep @connection_wait_time
-      establish_connection
-      retry
-    end
+    era_container = @swift_connection.container(swift_container)
 
     # Add swift metadata with in accordance to AIP spec:
     # https://docs.google.com/document/d/154BqhDPAdGW-I9enrqLpBYbhkF9exX9lV3kMaijuwPg/edit#
@@ -61,26 +51,18 @@ class PushmiPullyu::SwiftDepositer
       # for update: construct hash for key/value pairs as strings,
       # and metadata as additional key/value string pairs in the hash
       headers = { 'etag' => checksum,
-                  'content-type' => 'application/x-tar',
-                  'X-Auth-New-Token' => 'true' }.merge(metadata)
+                  'content-type' => 'application/x-tar' }.merge(metadata)
       deposited_file = era_container.object(file_base_name)
       deposited_file.write(File.open(file_name), headers)
     else
       # for creating new: construct hash with symbols as keys, add metadata as a hash within the header hash
       headers = { etag: checksum,
                   content_type: 'application/x-tar',
-                  metadata: metadata,
-                  'X-Auth-New-Token' => 'true' }
+                  metadata: metadata }
       deposited_file = era_container.create_object(file_base_name, headers, File.open(file_name))
     end
 
     deposited_file
-  end
-
-  private
-
-  def establish_connection
-    @swift_connection = OpenStack::Connection.create(@swift_connection_parameters)
   end
 
 end

--- a/spec/pushmi_pullyu/swift_depositer_spec.rb
+++ b/spec/pushmi_pullyu/swift_depositer_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe PushmiPullyu::SwiftDepositer do
 
           expect(first_deposit.name).to eq(second_deposit.name)
           expect(first_deposit.container.name).to eq(second_deposit.container.name)
-        end.to change { swift_depositer.swift_connection.container('ERA').count.to_i }.by(1)
+        end.to change { swift_depositer.instance_variable_get('@swift_connection').container('ERA').count.to_i }.by(1)
       end
     end
 
@@ -59,7 +59,7 @@ RSpec.describe PushmiPullyu::SwiftDepositer do
         )
         expect(swift_depositer).not_to be_nil
         # rubocop:disable Layout/LineLength
-        expect(swift_depositer.swift_connection.connection.authtoken).to eq('gAAAAABl8hYAouKZJLkt8NDmuA2NjA1zOasGOAX-b2MfKpjiM_kf8sZHe42ipcs6Vb-57-aATajbTg54wIwhNhl2HKRfz5_rKfSJ0PnBQNFCVd4bKrdC0pHzoJMn9hkAa2tjBkqppBcMayvfqz-Ppxn0USnHw0z9zLLKDxGbRZwyhDJDhGOcIZg')
+        expect(swift_depositer.instance_variable_get('@swift_connection').connection.authtoken).to eq('gAAAAABl8hYAouKZJLkt8NDmuA2NjA1zOasGOAX-b2MfKpjiM_kf8sZHe42ipcs6Vb-57-aATajbTg54wIwhNhl2HKRfz5_rKfSJ0PnBQNFCVd4bKrdC0pHzoJMn9hkAa2tjBkqppBcMayvfqz-Ppxn0USnHw0z9zLLKDxGbRZwyhDJDhGOcIZg')
         # rubocop:enable Layout/LineLength
       end
     end

--- a/spec/pushmi_pullyu/swift_depositer_spec.rb
+++ b/spec/pushmi_pullyu/swift_depositer_spec.rb
@@ -67,12 +67,12 @@ RSpec.describe PushmiPullyu::SwiftDepositer do
     it 'uses ruby-openstack gem behaviour to refresh authentication token' do
       VCR.use_cassette('swift_new_deposit') do
         swift_depositer = PushmiPullyu::SwiftDepositer.new(username: 'test:tester',
-                                                          password: 'testing',
-                                                          tenant: 'tester',
-                                                          auth_url: 'http://127.0.0.1:8080/auth/v1.0',
-                                                          retry_auth: true)
+                                                           password: 'testing',
+                                                           tenant: 'tester',
+                                                           auth_url: 'http://127.0.0.1:8080/auth/v1.0',
+                                                           retry_auth: true)
 
-        expect(swift_depositer.instance_variable_get("@swift_connection")
+        expect(swift_depositer.instance_variable_get('@swift_connection')
                               .instance_variable_get('@connection')
                               .instance_variable_get('@retry_auth')).to be true
       end

--- a/spec/pushmi_pullyu/swift_depositer_spec.rb
+++ b/spec/pushmi_pullyu/swift_depositer_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-
+require 'byebug'
 RSpec.describe PushmiPullyu::SwiftDepositer do
   describe '#deposit_file' do
     it 'deposits new file' do
@@ -61,6 +61,20 @@ RSpec.describe PushmiPullyu::SwiftDepositer do
         # rubocop:disable Layout/LineLength
         expect(swift_depositer.instance_variable_get('@swift_connection').connection.authtoken).to eq('gAAAAABl8hYAouKZJLkt8NDmuA2NjA1zOasGOAX-b2MfKpjiM_kf8sZHe42ipcs6Vb-57-aATajbTg54wIwhNhl2HKRfz5_rKfSJ0PnBQNFCVd4bKrdC0pHzoJMn9hkAa2tjBkqppBcMayvfqz-Ppxn0USnHw0z9zLLKDxGbRZwyhDJDhGOcIZg')
         # rubocop:enable Layout/LineLength
+      end
+    end
+
+    it 'uses ruby-openstack gem behaviour to refresh authentication token' do
+      VCR.use_cassette('swift_new_deposit') do
+        swift_depositer = PushmiPullyu::SwiftDepositer.new(username: 'test:tester',
+                                                          password: 'testing',
+                                                          tenant: 'tester',
+                                                          auth_url: 'http://127.0.0.1:8080/auth/v1.0',
+                                                          retry_auth: true)
+
+        expect(swift_depositer.instance_variable_get("@swift_connection")
+                              .instance_variable_get('@connection')
+                              .instance_variable_get('@retry_auth')).to be true
       end
     end
   end

--- a/spec/pushmi_pullyu/swift_depositer_spec.rb
+++ b/spec/pushmi_pullyu/swift_depositer_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'byebug'
+
 RSpec.describe PushmiPullyu::SwiftDepositer do
   describe '#deposit_file' do
     it 'deposits new file' do
@@ -72,9 +72,7 @@ RSpec.describe PushmiPullyu::SwiftDepositer do
                                                            auth_url: 'http://127.0.0.1:8080/auth/v1.0',
                                                            retry_auth: true)
 
-        expect(swift_depositer.instance_variable_get('@swift_connection')
-                              .instance_variable_get('@connection')
-                              .instance_variable_get('@retry_auth')).to be true
+        expect(swift_depositer.inspect).to include '@retry_auth=true' # retry_auth isn't exposed
       end
     end
   end


### PR DESCRIPTION
## Context

We've been having multiple authentication token errors due to invalidation. This PR Fixes this

Related to #315 

## What's New

- Set a parameter default value that makes the ruby-openstack gem retry to refresh the auth token.
- Add an http header to refresh the token on each call.
- Catch the exception when a token is invalid and recreate the connection.
