### PR TITLE
Use File.open with a block for simple exception handling and ensuring files are closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and releases in PushmiPullyu adheres to [Semantic Versioning](https://semver.org
 ### Added
  - Bring in and enforce inclusive language cops [PR#469](https://github.com/ualbertalib/pushmi_pullyu/pull/469)
 
+### Fixed
+ - Use `File.open` with a block for simple exception handling and ensuring files are closed [#475](https://github.com/ualbertalib/pushmi_pullyu/issues/475)
+
 ## [2.1.3]
  - Refresh authentication token after it expires [#311](https://github.com/ualbertalib/pushmi_pullyu/issues/311)
 

--- a/lib/pushmi_pullyu/aip/creator.rb
+++ b/lib/pushmi_pullyu/aip/creator.rb
@@ -41,7 +41,9 @@ class PushmiPullyu::AIP::Creator
     tar_aip_filename = File.expand_path(@aip_filename)
 
     Dir.chdir(PushmiPullyu.options[:workdir]) do
-      Minitar.pack(@noid, File.open(tar_aip_filename, 'wb'))
+      File.open(tar_aip_filename, 'wb') do |tar|
+        Minitar.pack(@noid, tar)
+      end
     end
   end
 

--- a/lib/pushmi_pullyu/swift_depositer.rb
+++ b/lib/pushmi_pullyu/swift_depositer.rb
@@ -53,13 +53,17 @@ class PushmiPullyu::SwiftDepositer
       headers = { 'etag' => checksum,
                   'content-type' => 'application/x-tar' }.merge(metadata)
       deposited_file = era_container.object(file_base_name)
-      deposited_file.write(File.open(file_name), headers)
+      File.open(file_name) do |file|
+        deposited_file.write(file, headers)
+      end
     else
       # for creating new: construct hash with symbols as keys, add metadata as a hash within the header hash
       headers = { etag: checksum,
                   content_type: 'application/x-tar',
                   metadata: metadata }
-      deposited_file = era_container.create_object(file_base_name, headers, File.open(file_name))
+      File.open(file_name) do |file|
+        deposited_file = era_container.create_object(file_base_name, headers, file)
+      end
     end
 
     deposited_file


### PR DESCRIPTION
## Context

@beausapach asked "Is there a process that's holding the file open?  The space may not be freed until it's closed, which would happen at shutdown."

With no associated block, `File.open` is a synonym for `File.new`.  The `new` method returns a `File` instance that you can then read or write from. The file remains open until `close` is called on the instance. Once the file variable goes out of scope, then garbage collection will eventually close it, but this may not happen for a while. Meanwhile, resources are being held open.  (From [Ruby 3.3: Opening and Closing Files](https://learning.oreilly.com/library/view/programming-ruby-3-3/9798888650684/f_0082.xhtml#d25e38151))

Related to #475 

## What's New

Use File.open with a block for simple exception handling and ensuring files are closed