### PR TITLE
Permit versions of activesupport that work with Ruby 2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and releases in PushmiPullyu adheres to [Semantic Versioning](https://semver.org
 
 ## [Unreleased]
 
+### Fixed
+- Permit versions of dependencies that work with Ruby 2.7
+
 ## [2.1.4]
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,14 +2,14 @@ PATH
   remote: .
   specs:
     pushmi_pullyu (2.1.4)
-      activesupport (>= 5, < 8)
+      activesupport (>= 5, < 7.2)
       bagit (~> 0.4)
       connection_pool (~> 2.2)
       daemons (~> 1.2, >= 1.2.4)
-      minitar (>= 0.7, < 2.0)
+      minitar (>= 0.7, < 1.0)
       openstack (~> 3.3, >= 3.3.10)
-      rdf (>= 1.99, < 4.0)
-      rdf-n3 (>= 1.99, < 4.0)
+      rdf (>= 1.99, < 3.3)
+      rdf-n3 (>= 1.99, < 3.3)
       redis (>= 3.3, < 6.0)
       rest-client (>= 1.8, < 3.0)
       rollbar (>= 2.18, < 4.0)

--- a/pushmi_pullyu.gemspec
+++ b/pushmi_pullyu.gemspec
@@ -21,14 +21,14 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.7'
 
-  spec.add_dependency 'activesupport', '>= 5', '< 8'
+  spec.add_dependency 'activesupport', '>= 5', '< 7.2'
   spec.add_dependency 'bagit', '~> 0.4'
   spec.add_dependency 'connection_pool', '~> 2.2'
   spec.add_dependency 'daemons', '~> 1.2', '>= 1.2.4'
-  spec.add_dependency 'minitar', '>= 0.7', '< 2.0'
+  spec.add_dependency 'minitar', '>= 0.7', '< 1.0'
   spec.add_dependency 'openstack', '~> 3.3', '>= 3.3.10'
-  spec.add_dependency 'rdf', '>= 1.99', '< 4.0'
-  spec.add_dependency 'rdf-n3', '>= 1.99', '< 4.0'
+  spec.add_dependency 'rdf', '>= 1.99', '< 3.3'
+  spec.add_dependency 'rdf-n3', '>= 1.99', '< 3.3'
   spec.add_dependency 'redis', '>= 3.3', '< 6.0'
   spec.add_dependency 'rest-client', '>= 1.8', '< 3.0'
   spec.add_dependency 'rollbar', '>= 2.18', '< 4.0'


### PR DESCRIPTION
## Context
We've had troubles deploying 2.1.4 in staging.  We observed it installing newer versions of gems versus what was in our Gemfile.lock that don't work in Ruby 2.7.

## What's New
Adjust pushmi_pullyu.gemspec to avoid gems that only work in Ruby 3+ environments.