### PR TITLE
Pin version of securerandom that work with Ruby 2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and releases in PushmiPullyu adheres to [Semantic Versioning](https://semver.org
 
 ## [Unreleased]
 
+### Fixed
+- pin version of securerandom that work with Ruby 2.7
+
 ## [2.1.5] 2024-11-27
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,7 @@ PATH
       redis (>= 3.3, < 6.0)
       rest-client (>= 1.8, < 3.0)
       rollbar (>= 2.18, < 4.0)
+      securerandom (~> 0.3.2)
       uuid (~> 2.3.9)
 
 GEM
@@ -196,6 +197,7 @@ GEM
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
     scanf (1.0.0)
+    securerandom (0.3.2)
     sparql (3.2.6)
       builder (~> 3.2, >= 3.2.4)
       ebnf (~> 2.3, >= 2.3.5)

--- a/pushmi_pullyu.gemspec
+++ b/pushmi_pullyu.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'redis', '>= 3.3', '< 6.0'
   spec.add_dependency 'rest-client', '>= 1.8', '< 3.0'
   spec.add_dependency 'rollbar', '>= 2.18', '< 4.0'
+  spec.add_dependency 'securerandom', '~> 0.3.2'
   spec.add_dependency 'uuid', '~> 2.3.9'
 
   spec.metadata = {


### PR DESCRIPTION
## Context
Staging is blocked by deployment issue. Recent minor releases of gem dependencies have move to require Ruby 3.x because 2.7 is eol. We pin major versions in pushmi_pullyu.gemspec

Related to #492 

## What's New
Pin securerandom to 0.3.2 (0.4.0 depends on Ruby 3)